### PR TITLE
run all .py files through autopep8

### DIFF
--- a/PySpectrograph/Identify/AutoIdentify.py
+++ b/PySpectrograph/Identify/AutoIdentify.py
@@ -31,8 +31,8 @@
 # POSSIBILITY OF SUCH DAMAGE.                                              #
 ############################################################################
 """
-AutoIDENTIFY  is a program to automatically identify spectral lines in 
-an arc image.  
+AutoIDENTIFY  is a program to automatically identify spectral lines in
+an arc image.
 
 Author                 Version      Date
 -----------------------------------------------
@@ -48,12 +48,15 @@ LIMITATIONS
 """
 # Ensure python 2.5 compatibility
 
-import os, sys
+import os
+import sys
 import time
 import numpy as np
 
-from pyraf import iraf 
-import saltprint, saltio, saltkey
+from pyraf import iraf
+import saltprint
+import saltio
+import saltkey
 import saltsafekey
 import saltsafeio
 from saltsafelog import logging
@@ -66,186 +69,185 @@ from PySpectrograph import WavelengthSolution
 from PySpectrograph.detectlines import detectlines
 
 
-import spectools as st
-from spectools import SALTSpecError
+from . import spectools as st
+from .spectools import SALTSpecError
 
-debug=True
-
-def AutoIdentify(xarr, specarr, slines, sfluxes, ws, method='Zeropoint',   \
-                     rstep=1, icenter=None, nrows=1, res=2, dres=0.1,        \
-                     sigma=5, niter=5, \
-                     dc=20, nstep=20, \
-                     verbose=True):
-   """Automatically find the wavlength solution for the entire image.  The following 
-      methods are used:
-
-      zeropoint--Assume that the form for the initial guess of the wavelength solution
-                 is correct
-   """
-   ImageSolution={}
-
-   #run it if only the zeropoint needs to be calculated
-   if method=='Zeropoint':
-      func=st.findzeropoint
-      ImageSolution=runsolution(xarr, specarr, slines, sfluxes, ws, func, fline=False, oneline=False, \
-                  rstep=rstep, icenter=icenter, nrows=nrows, res=res, dres=dres,      \
-                  dsigma=sigma, dniter=niter, verbose=verbose, dc=dc, nstep=nstep)
-      print method
-
-   #use a line matching algorithm to match the lines
-   #in the image with those in the line list
-   if method=='Matchlines':
-      func=st.findwavelengthsolution
-      ImageSolution=runsolution(xarr, specarr, slines, sfluxes, ws, func, fline=True, oneline=False,\
-                  rstep=rstep, icenter=icenter, nrows=nrows, res=res, dres=dres,      \
-                  dsigma=sigma, dniter=niter, verbose=verbose, sigma=sigma, niter=niter)
-
-   #first fit a zeropoint, then match the lines, and then 
-   #find the rest of the points by using only the zeropoint
-   if method=='MatchZero':
-      print ws.coef
-      func=st.findzeropoint
-      ws=runsolution(xarr, specarr, slines, sfluxes, ws, func, fline=False, oneline=True, \
-                  rstep=rstep, icenter=icenter, nrows=nrows, res=res, dres=dres,      \
-                  dsigma=sigma, dniter=niter, verbose=verbose, dc=10, nstep=20)
-
-      func=st.findwavelengthsolution
-      ws=runsolution(xarr, specarr, slines, sfluxes, ws, func, fline=True, oneline=True,\
-                  rstep=rstep, icenter=icenter, nrows=nrows, res=res, dres=dres,      \
-                  dsigma=sigma, dniter=niter, verbose=verbose, sigma=sigma, niter=niter)
-      print 'Running zero now'
-      func=st.findzeropoint
-      ImageSolution=runsolution(xarr, specarr, slines, sfluxes, ws, func, fline=False, oneline=False, \
-                  rstep=rstep, icenter=icenter, nrows=nrows, res=res, dres=dres,      \
-                  dsigma=sigma, dniter=niter, verbose=verbose, dc=dc, nstep=nstep)
-
-      print method
-
-   if method=='FullXcor':
-      func=st.findxcor 
-      dcoef=ws.coef*0.1
-      dcoef[-1]=dc
-      print dcoef
-      ws=runsolution(xarr, specarr, slines, sfluxes, ws, func, fline=True, oneline=True,\
-                  rstep=rstep, icenter=icenter, nrows=nrows, res=res, dres=dres,      \
-                  dsigma=sigma, dniter=niter, verbose=verbose, dcoef=dcoef)
-      print 'Running zero now'
-      func=st.findzeropoint
-      ImageSolution=runsolution(xarr, specarr, slines, sfluxes, ws, func, fline=False, oneline=False, \
-                  rstep=rstep, icenter=icenter, nrows=nrows, res=res, dres=dres,      \
-                  dsigma=sigma, dniter=niter, verbose=verbose, dc=dc, nstep=nstep)
+debug = True
 
 
-      print method
+def AutoIdentify(xarr, specarr, slines, sfluxes, ws, method='Zeropoint',
+                 rstep=1, icenter=None, nrows=1, res=2, dres=0.1,
+                 sigma=5, niter=5,
+                 dc=20, nstep=20,
+                 verbose=True):
+    """Automatically find the wavlength solution for the entire image.  The following
+       methods are used:
 
-   return ImageSolution
-   
-def runsolution(xarr, specarr, slines, sfluxes, ws,  func, ivar=None,          \
+       zeropoint--Assume that the form for the initial guess of the wavelength solution
+                  is correct
+    """
+    ImageSolution = {}
+
+    # run it if only the zeropoint needs to be calculated
+    if method == 'Zeropoint':
+        func = st.findzeropoint
+        ImageSolution = runsolution(xarr, specarr, slines, sfluxes, ws, func, fline=False, oneline=False,
+                                    rstep=rstep, icenter=icenter, nrows=nrows, res=res, dres=dres,
+                                    dsigma=sigma, dniter=niter, verbose=verbose, dc=dc, nstep=nstep)
+        print method
+
+    # use a line matching algorithm to match the lines
+    # in the image with those in the line list
+    if method == 'Matchlines':
+        func = st.findwavelengthsolution
+        ImageSolution = runsolution(xarr, specarr, slines, sfluxes, ws, func, fline=True, oneline=False,
+                                    rstep=rstep, icenter=icenter, nrows=nrows, res=res, dres=dres,
+                                    dsigma=sigma, dniter=niter, verbose=verbose, sigma=sigma, niter=niter)
+
+    # first fit a zeropoint, then match the lines, and then
+    # find the rest of the points by using only the zeropoint
+    if method == 'MatchZero':
+        print ws.coef
+        func = st.findzeropoint
+        ws = runsolution(xarr, specarr, slines, sfluxes, ws, func, fline=False, oneline=True,
+                         rstep=rstep, icenter=icenter, nrows=nrows, res=res, dres=dres,
+                         dsigma=sigma, dniter=niter, verbose=verbose, dc=10, nstep=20)
+
+        func = st.findwavelengthsolution
+        ws = runsolution(xarr, specarr, slines, sfluxes, ws, func, fline=True, oneline=True,
+                         rstep=rstep, icenter=icenter, nrows=nrows, res=res, dres=dres,
+                         dsigma=sigma, dniter=niter, verbose=verbose, sigma=sigma, niter=niter)
+        print 'Running zero now'
+        func = st.findzeropoint
+        ImageSolution = runsolution(xarr, specarr, slines, sfluxes, ws, func, fline=False, oneline=False,
+                                    rstep=rstep, icenter=icenter, nrows=nrows, res=res, dres=dres,
+                                    dsigma=sigma, dniter=niter, verbose=verbose, dc=dc, nstep=nstep)
+
+        print method
+
+    if method == 'FullXcor':
+        func = st.findxcor
+        dcoef = ws.coef * 0.1
+        dcoef[-1] = dc
+        print dcoef
+        ws = runsolution(xarr, specarr, slines, sfluxes, ws, func, fline=True, oneline=True,
+                         rstep=rstep, icenter=icenter, nrows=nrows, res=res, dres=dres,
+                         dsigma=sigma, dniter=niter, verbose=verbose, dcoef=dcoef)
+        print 'Running zero now'
+        func = st.findzeropoint
+        ImageSolution = runsolution(xarr, specarr, slines, sfluxes, ws, func, fline=False, oneline=False,
+                                    rstep=rstep, icenter=icenter, nrows=nrows, res=res, dres=dres,
+                                    dsigma=sigma, dniter=niter, verbose=verbose, dc=dc, nstep=nstep)
+
+        print method
+
+    return ImageSolution
+
+
+def runsolution(xarr, specarr, slines, sfluxes, ws, func, ivar=None,
                 fline=True, oneline=False,
-                rstep=20,\
+                rstep=20,
                 icenter=None, nrows=1, dsigma=5, dniter=5, res=2.0, dres=0.1, verbose=True, **kwargs):
-   """Starting in the middle of the image, it will determine the solution
-      by working its way out to either edge and compiling all the results into 
-      ImageSolution
+    """Starting in the middle of the image, it will determine the solution
+       by working its way out to either edge and compiling all the results into
+       ImageSolution
 
-      xarr--Full range in x of pixels to solve for
-   
-      specarr--Input 2D flux
+       xarr--Full range in x of pixels to solve for
 
-      func--function to use for the solution
+       specarr--Input 2D flux
+
+       func--function to use for the solution
 
 
-   """
-   #set up the variables
-   ImageSolution={}
+    """
+    # set up the variables
+    ImageSolution = {}
 
-   #Setup the central line if it isn't specified
-   if icenter==None: icenter=int(0.5*len(specarr))
+    # Setup the central line if it isn't specified
+    if icenter is None:
+        icenter = int(0.5 * len(specarr))
 
-   #set up the flux from the central line (or the line specified by the user in icenter)
-   specext=apext.apext(xarr, specarr, ivar=ivar)
-   farr=apext.makeflat(specarr, icenter, icenter+nrows)
-   farr=st.flatspectrum(xarr, farr, mode='poly', order=2)
-   cxp=st.detectlines(xarr, farr, dsigma, dniter)
-   nlines=len(cxp)
+    # set up the flux from the central line (or the line specified by the user in icenter)
+    specext = apext.apext(xarr, specarr, ivar=ivar)
+    farr = apext.makeflat(specarr, icenter, icenter + nrows)
+    farr = st.flatspectrum(xarr, farr, mode='poly', order=2)
+    cxp = st.detectlines(xarr, farr, dsigma, dniter)
+    nlines = len(cxp)
 
-       
-   #first set up the artificial spectrum
-   swarr, sfarr=st.makeartificial(slines, sfluxes, farr.max(), res, dres)
-   
-   #find the solution for the central wavelegnth
-   k=icenter
-   min_lines=0.1*len(cxp)
-   if fline:
-       mws=solution(xarr, specarr, slines, sfluxes, ws, func, k, k+nrows, \
-                    min_lines=min_lines, dsigma=dsigma, dniter=dniter, **kwargs)
-   else:
-       mws=solution(xarr, specarr, swarr, sfarr, ws, func, k, k+nrows, \
-                    min_lines=min_lines,dsigma=dsigma, dniter=dniter, **kwargs)
-   
-   print 'runsolution:', mws.coef
-   if oneline:  return mws
+    # first set up the artificial spectrum
+    swarr, sfarr = st.makeartificial(slines, sfluxes, farr.max(), res, dres)
 
-   ImageSolution[k]=mws
+    # find the solution for the central wavelegnth
+    k = icenter
+    min_lines = 0.1 * len(cxp)
+    if fline:
+        mws = solution(xarr, specarr, slines, sfluxes, ws, func, k, k + nrows,
+                       min_lines=min_lines, dsigma=dsigma, dniter=dniter, **kwargs)
+    else:
+        mws = solution(xarr, specarr, swarr, sfarr, ws, func, k, k + nrows,
+                       min_lines=min_lines, dsigma=dsigma, dniter=dniter, **kwargs)
 
-   #now loop through each step, and calculate the wavelengths for the given 
-   for i in range(rstep,int(0.5*len(specarr)), rstep):
-       for k in [icenter-i, icenter+i]:
-           lws=getwsfromIS(k, ImageSolution)
-           if fline:
-               fws=solution(xarr, specarr, slines, sfluxes, lws, func, k, k+nrows,  \
-                            min_lines=min_lines, dsigma=dsigma, dniter=dniter, **kwargs)
-           else:
-               fws=solution(xarr, specarr, swarr, sfarr, lws, func, k, k+nrows,     \
-                            min_lines=min_lines, dsigma=dsigma, dniter=dniter, **kwargs)
-           ImageSolution[k]=fws
+    print 'runsolution:', mws.coef
+    if oneline:
+        return mws
 
-           if verbose:
-              p_new=i*100.0/(0.5*len(specarr))
-              ctext='Percentage Complete: %d %d %f\r' % (i,p_new, time.clock()) #p_new
-              sys.stdout.write(ctext)
-              sys.stdout.flush()
+    ImageSolution[k] = mws
 
-   return ImageSolution
+    # now loop through each step, and calculate the wavelengths for the given
+    for i in range(rstep, int(0.5 * len(specarr)), rstep):
+        for k in [icenter - i, icenter + i]:
+            lws = getwsfromIS(k, ImageSolution)
+            if fline:
+                fws = solution(xarr, specarr, slines, sfluxes, lws, func, k, k + nrows,
+                               min_lines=min_lines, dsigma=dsigma, dniter=dniter, **kwargs)
+            else:
+                fws = solution(xarr, specarr, swarr, sfarr, lws, func, k, k + nrows,
+                               min_lines=min_lines, dsigma=dsigma, dniter=dniter, **kwargs)
+            ImageSolution[k] = fws
+
+            if verbose:
+                p_new = i * 100.0 / (0.5 * len(specarr))
+                ctext = 'Percentage Complete: %d %d %f\r' % (i, p_new, time.clock())  # p_new
+                sys.stdout.write(ctext)
+                sys.stdout.flush()
+
+    return ImageSolution
+
 
 def solution(xarr, specarr, sl, sf, ws, func, y1, y2, min_lines=2, dsigma=5, dniter=3, pad=50, **kwargs):
-   """Extract a single line and calculate the wavelneght solution"""
+    """Extract a single line and calculate the wavelneght solution"""
 
-   #set up the flux from the set of lines
-   farr=apext.makeflat(specarr, y1, y2)
-   farr=st.flatspectrum(xarr, farr, mode='poly', order=2)
+    # set up the flux from the set of lines
+    farr = apext.makeflat(specarr, y1, y2)
+    farr = st.flatspectrum(xarr, farr, mode='poly', order=2)
 
-   #check to see if there are any points
-   xp=st.detectlines(xarr, farr, dsigma, dniter)
+    # check to see if there are any points
+    xp = st.detectlines(xarr, farr, dsigma, dniter)
 
-   if len(xp) > min_lines and ws:
-       #make the artificial list
-       wmin=ws.value(xarr.min())
-       wmax=ws.value(xarr.max())
-       smask=(sl>wmin-pad)*(sl<wmax+pad)
+    if len(xp) > min_lines and ws:
+        # make the artificial list
+        wmin = ws.value(xarr.min())
+        wmax = ws.value(xarr.max())
+        smask = (sl > wmin - pad) * (sl < wmax + pad)
 
-       #fit the function
-       fws=func(xarr, farr, sl[smask], sf[smask], ws, **kwargs)
-       return fws
+        # fit the function
+        fws = func(xarr, farr, sl[smask], sf[smask], ws, **kwargs)
+        return fws
 
-   return None
+    return None
+
 
 def getwsfromIS(k, ImageSolution):
     """From the imageSolution dictionary, find the ws which is nearest to the value k
 
     """
-    ISkeys=np.array(ImageSolution.keys())
-    ws=ImageSolution[ISkeys[abs(ISkeys-k).argmin()]]
-    if ws==None:
-       dist=abs(ISkeys[0]-k)
-       ws=ImageSolution[ISkeys[0]]
-       for i in ISkeys:
-           if ImageSolution[i] and abs(i-k)<dist:
-               dist=abs(i-k)
-               ws=ImageSolution[i]
+    ISkeys = np.array(ImageSolution.keys())
+    ws = ImageSolution[ISkeys[abs(ISkeys - k).argmin()]]
+    if ws is None:
+        dist = abs(ISkeys[0] - k)
+        ws = ImageSolution[ISkeys[0]]
+        for i in ISkeys:
+            if ImageSolution[i] and abs(i - k) < dist:
+                dist = abs(i - k)
+                ws = ImageSolution[i]
     return ws
-    
-
-    
-
-

--- a/PySpectrograph/Identify/Identify.py
+++ b/PySpectrograph/Identify/Identify.py
@@ -1,3 +1,3 @@
 """IDENTIFY is a task that determines the wavelength calibration for an
-array.   The information that needs to be supplied to identify is the 
+array.   The information that needs to be supplied to identify is the
 1- or 2-D data array"""

--- a/PySpectrograph/Identify/InterIdentify.py
+++ b/PySpectrograph/Identify/InterIdentify.py
@@ -30,13 +30,13 @@
 # POSSIBILITY OF SUCH DAMAGE.                                              #
 ############################################################################
 
-"""INTERIDENTIFY provides an interactive method for identifying 
-lines in an arc image.  The tasks displays the full image, a 
+"""INTERIDENTIFY provides an interactive method for identifying
+lines in an arc image.  The tasks displays the full image, a
 line extracted from the image, and residuals to the fit of that line.
 The task will display the total image so the user can extract the lines
 to be fit.  Or the user can automate the process so only certain lines are
-fit by the user.  On the next tab, the task displays the arc line 
-and the fit to the line including what lines have been detected and 
+fit by the user.  On the next tab, the task displays the arc line
+and the fit to the line including what lines have been detected and
 are being used for the fit.  Finally the task displays the residual in
 the fit and the user can select different options to be displayed.
 
@@ -80,39 +80,40 @@ from PySpectrograph import Spectrum
 #from PySpectrograph import WavelengthSolution
 #from PySpectrograph.detectlines import detectlines
 
-import spectools as st
-from spectools import SALTSpecError
+from . import spectools as st
+from .spectools import SALTSpecError
 
 
 class InterIdentifyWindow(QtGui.QMainWindow):
-   """Main application window."""
 
-   def __init__(self, xarr, specarr, slines, sfluxes, ws, hmin=150, wmin=400, 
-                filename=None, res=2.0, dres=0.1, sigma=5, niter=5,
-                ivar=None, nrows=1, nsteps=100, cmap='gray', scale='zscale', contrast=1.0):
+    """Main application window."""
+
+    def __init__(self, xarr, specarr, slines, sfluxes, ws, hmin=150, wmin=400,
+                 filename=None, res=2.0, dres=0.1, sigma=5, niter=5,
+                 ivar=None, nrows=1, nsteps=100, cmap='gray', scale='zscale', contrast=1.0):
         """Default constructor."""
 
-        #set up the variables
-        self.y1=int(0.5*len(specarr))
-        self.y2=self.y1+nrows
-        self.specarr=specarr
-        self.xarr=xarr
-        self.ivar=ivar
-        self.slines=slines
-        self.sfluxes=sfluxes
-        self.hmin=hmin
-        self.wmin=wmin
-        self.ws=ws
-        self.res=res
-        self.dres=dres
-        self.sigma=sigma
-        self.niter=niter
-        self.nrows=nrows
-        self.cmap=cmap
-        self.scale=scale
-        self.contrast=contrast
-        self.filename=filename
-        self.ImageSolution={}
+        # set up the variables
+        self.y1 = int(0.5 * len(specarr))
+        self.y2 = self.y1 + nrows
+        self.specarr = specarr
+        self.xarr = xarr
+        self.ivar = ivar
+        self.slines = slines
+        self.sfluxes = sfluxes
+        self.hmin = hmin
+        self.wmin = wmin
+        self.ws = ws
+        self.res = res
+        self.dres = dres
+        self.sigma = sigma
+        self.niter = niter
+        self.nrows = nrows
+        self.cmap = cmap
+        self.scale = scale
+        self.contrast = contrast
+        self.filename = filename
+        self.ImageSolution = {}
 
         # Setup widget
         QtGui.QMainWindow.__init__(self)
@@ -123,34 +124,41 @@ class InterIdentifyWindow(QtGui.QMainWindow):
         # Set window title
         self.setWindowTitle("InterIdentify")
 
-        #create the Image page
-        self.imagePage=imageWidget(self.specarr, y1=self.y1, y2=self.y2, hmin=self.hmin, wmin=self.wmin, cmap=self.cmap, 
-                                   name=self.filename, scale=self.scale, contrast=self.contrast)
+        # create the Image page
+        self.imagePage = imageWidget(self.specarr, y1=self.y1, y2=self.y2, hmin=self.hmin, wmin=self.wmin, cmap=self.cmap,
+                                     name=self.filename, scale=self.scale, contrast=self.contrast)
 
-        #set up the arc page
-        self.farr=apext.makeflat(self.specarr, self.y1, self.y2)
+        # set up the arc page
+        self.farr = apext.makeflat(self.specarr, self.y1, self.y2)
 
-        #set up variables
-        self.arcdisplay=ArcDisplay(xarr, self.farr, slines, sfluxes, self.ws, res=self.res, dres=self.dres, niter=self.niter, sigma=self.sigma)
-        self.arcPage=arcWidget(self.arcdisplay,  hmin=hmin, wmin=wmin, y1=self.y1, y2=self.y2)
-        #set up the residual page
-        self.errPage=errWidget(self.arcdisplay, hmin=hmin, wmin=wmin)
+        # set up variables
+        self.arcdisplay = ArcDisplay(
+            xarr,
+            self.farr,
+            slines,
+            sfluxes,
+            self.ws,
+            res=self.res,
+            dres=self.dres,
+            niter=self.niter,
+            sigma=self.sigma)
+        self.arcPage = arcWidget(self.arcdisplay, hmin=hmin, wmin=wmin, y1=self.y1, y2=self.y2)
+        # set up the residual page
+        self.errPage = errWidget(self.arcdisplay, hmin=hmin, wmin=wmin)
 
-
-        #create the tabs
-        self.tabWidget=QtGui.QTabWidget()
+        # create the tabs
+        self.tabWidget = QtGui.QTabWidget()
         self.tabWidget.addTab(self.imagePage, 'Image')
         self.tabWidget.addTab(self.arcPage, 'Arc')
         self.tabWidget.addTab(self.errPage, 'Residual')
- 
-        #layout the widgets
+
+        # layout the widgets
         mainLayout = QtGui.QVBoxLayout(self.main)
         mainLayout.addWidget(self.tabWidget)
-        #self.setLayout(mainLayout)
-
+        # self.setLayout(mainLayout)
 
         # Set focus to main widget
-        #self.main.setFocus()
+        # self.main.setFocus()
 
         # Set the main widget as the central widget
         self.setCentralWidget(self.main)
@@ -163,55 +171,68 @@ class InterIdentifyWindow(QtGui.QMainWindow):
         self.connect(self.tabWidget, QtCore.SIGNAL('currentChanged(int)'), self.currentChanged)
         self.connect(self.imagePage, QtCore.SIGNAL('regionChange(int,int)'), self.regionChange)
 
-   def keyPressEvent(self, event):
-       print "Key Pressed:", event.key
+    def keyPressEvent(self, event):
+        print "Key Pressed:", event.key
 
-   def currentChanged(self, event):
-       print event
+    def currentChanged(self, event):
+        print event
 
-   def regionChange(self, y1, y2):
-       self.saveWS()
-       print "RegionChange:", y1, y2
-       self.y1=y1
-       self.y2=y2
-       self.farr=apext.makeflat(self.specarr, self.y1, self.y2)
-       #set up variables
-       print "FINAL WS:", self.ws.coef
-       self.ws=self.newWS(0.5*(self.y1+self.y2))
-       self.arcdisplay=ArcDisplay(self.xarr, self.farr, self.slines, self.sfluxes, self.ws, res=self.res, dres=self.dres, niter=self.niter, sigma=self.sigma, xp=[], wp=[])
-       self.arcPage=arcWidget(self.arcdisplay,  hmin=self.hmin, wmin=self.wmin, y1=self.y1, y2=self.y2)
-       #set up the residual page
-       self.errPage=errWidget(self.arcdisplay, hmin=self.hmin, wmin=self.wmin)
-       #reset the pages
-       self.tabWidget.removeTab(2)
-       self.tabWidget.removeTab(1)
-       self.tabWidget.insertTab(1, self.arcPage, 'Arc')
-       self.tabWidget.insertTab(2, self.errPage, 'Residual')
+    def regionChange(self, y1, y2):
+        self.saveWS()
+        print "RegionChange:", y1, y2
+        self.y1 = y1
+        self.y2 = y2
+        self.farr = apext.makeflat(self.specarr, self.y1, self.y2)
+        # set up variables
+        print "FINAL WS:", self.ws.coef
+        self.ws = self.newWS(0.5 * (self.y1 + self.y2))
+        self.arcdisplay = ArcDisplay(
+            self.xarr,
+            self.farr,
+            self.slines,
+            self.sfluxes,
+            self.ws,
+            res=self.res,
+            dres=self.dres,
+            niter=self.niter,
+            sigma=self.sigma,
+            xp=[],
+            wp=[])
+        self.arcPage = arcWidget(self.arcdisplay, hmin=self.hmin, wmin=self.wmin, y1=self.y1, y2=self.y2)
+        # set up the residual page
+        self.errPage = errWidget(self.arcdisplay, hmin=self.hmin, wmin=self.wmin)
+        # reset the pages
+        self.tabWidget.removeTab(2)
+        self.tabWidget.removeTab(1)
+        self.tabWidget.insertTab(1, self.arcPage, 'Arc')
+        self.tabWidget.insertTab(2, self.errPage, 'Residual')
 
-   def saveWS(self):
-       self.ws=self.arcdisplay.ws
-       k=0.5*(self.y1+self.y2)
-       self.ImageSolution[k]=self.ws
+    def saveWS(self):
+        self.ws = self.arcdisplay.ws
+        k = 0.5 * (self.y1 + self.y2)
+        self.ImageSolution[k] = self.ws
 
-   def newWS(self, y):
-       """Determine the WS closest to the values given by y1 and y2"""
-       keys=np.array(self.ImageSolution.keys())
-       print "keys:",keys
-       i=abs(keys-y).argmin()
-       print i, keys[i]
-       return self.ImageSolution[keys[i]]
+    def newWS(self, y):
+        """Determine the WS closest to the values given by y1 and y2"""
+        keys = np.array(self.ImageSolution.keys())
+        print "keys:", keys
+        i = abs(keys - y).argmin()
+        print i, keys[i]
+        return self.ImageSolution[keys[i]]
 
 
 class imageWidget(QtGui.QWidget):
-    def __init__(self, imarr, y1=None, y2=None, nrows=1, nsteps=100, hmin=150, wmin=400, name=None, cmap='Gray', scale='zscale', contrast=0.1, parent=None):
+
+    def __init__(self, imarr, y1=None, y2=None, nrows=1, nsteps=100, hmin=150, wmin=400,
+                 name=None, cmap='Gray', scale='zscale', contrast=0.1, parent=None):
         super(imageWidget, self).__init__(parent)
 
-        self.y1=y1
-        self.y2=y2
-        self.x1=0 
-        self.x2=len(imarr[0])
-        self.nrows=nrows
-        self.nsteps=nsteps
+        self.y1 = y1
+        self.y2 = y2
+        self.x1 = 0
+        self.x2 = len(imarr[0])
+        self.nrows = nrows
+        self.nsteps = nsteps
 
         # Add FITS display widget with mouse interaction and overplotting
         self.imdisplay = ImageDisplay()
@@ -222,49 +243,48 @@ class imageWidget(QtGui.QWidget):
         self.imdisplay.setColormap(cmap)
 
         # Set scale mode for dynamic range
-        self.imdisplay.scale=scale
-        self.imdisplay.contrast=contrast
-        self.imdisplay.aspect='auto'
+        self.imdisplay.scale = scale
+        self.imdisplay.contrast = contrast
+        self.imdisplay.aspect = 'auto'
         self.imdisplay.loadImage(imarr)
         self.imdisplay.drawImage()
-        self.y1line,=self.imdisplay.axes.plot([self.x1, self.x2],[self.y1,self.y1], ls='-', color='#00FF00')
-        self.y2line,=self.imdisplay.axes.plot([self.x1, self.x2],[self.y2,self.y2], ls='-', color='#00FF00')
+        self.y1line, = self.imdisplay.axes.plot([self.x1, self.x2], [self.y1, self.y1], ls='-', color='#00FF00')
+        self.y2line, = self.imdisplay.axes.plot([self.x1, self.x2], [self.y2, self.y2], ls='-', color='#00FF00')
 
         # Add navigation toolbars for each widget to enable zooming
-        self.toolbar=NavigationToolbar2QTAgg(self.imdisplay,self)
+        self.toolbar = NavigationToolbar2QTAgg(self.imdisplay, self)
 
-        #set up the information panel
-        self.infopanel=QtGui.QWidget()
+        # set up the information panel
+        self.infopanel = QtGui.QWidget()
 
-        #add the name of the file
+        # add the name of the file
         self.NameLabel = QtGui.QLabel("Filename:")
-        self.NameLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised )
+        self.NameLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised)
         self.NameValueLabel = QtGui.QLabel("%s" % name)
-        self.NameValueLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Sunken )
+        self.NameValueLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Sunken)
 
-        #add the rows that are extracted
+        # add the rows that are extracted
         self.y1Label = QtGui.QLabel("Y1:")
-        self.y1Label.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised )
+        self.y1Label.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised)
         self.y1ValueEdit = QtGui.QLineEdit("%6i" % self.y1)
         self.y2Label = QtGui.QLabel("Y2:")
-        self.y2Label.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised )
+        self.y2Label.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised)
         self.y2ValueEdit = QtGui.QLineEdit("%6i" % self.y2)
         self.updateButton = QtGui.QPushButton("Update")
         self.updateButton.clicked.connect(self.updatesection)
 
-        #add the update for automatically updating it
+        # add the update for automatically updating it
         self.nrLabel = QtGui.QLabel("nrows:")
-        self.nrLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised )
+        self.nrLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised)
         self.nrValueEdit = QtGui.QLineEdit("%5i" % self.nrows)
         self.nsLabel = QtGui.QLabel("nsteps:")
-        self.nsLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised )
+        self.nsLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised)
         self.nsValueEdit = QtGui.QLineEdit("%6i" % self.nsteps)
         self.nextButton = QtGui.QPushButton("Next")
         self.nextButton.clicked.connect(self.nextsection)
 
-
-        #set up the info panel layout
-        infoLayout=QtGui.QGridLayout(self.infopanel)
+        # set up the info panel layout
+        infoLayout = QtGui.QGridLayout(self.infopanel)
         infoLayout.addWidget(self.NameLabel, 0, 0, 1, 1)
         infoLayout.addWidget(self.NameValueLabel, 0, 1, 1, 5)
         infoLayout.addWidget(self.y1Label, 1, 0, 1, 1)
@@ -278,7 +298,6 @@ class imageWidget(QtGui.QWidget):
         infoLayout.addWidget(self.nsValueEdit, 2, 3, 1, 1)
         infoLayout.addWidget(self.nextButton, 2, 4, 1, 1)
 
-
         # Set up the layout
         mainLayout = QtGui.QVBoxLayout()
         mainLayout.addWidget(self.imdisplay)
@@ -287,27 +306,27 @@ class imageWidget(QtGui.QWidget):
         self.setLayout(mainLayout)
 
     def updatesection(self):
-       self.y1=int(self.y1ValueEdit.text())
-       self.y2=int(self.y2ValueEdit.text())
-       self.y1line.set_ydata([self.y1, self.y1])
-       self.y2line.set_ydata([self.y2, self.y2])
-       self.imdisplay.draw()
-       self.emit(QtCore.SIGNAL("regionChange(int,int)"), self.y1, self.y2)
+        self.y1 = int(self.y1ValueEdit.text())
+        self.y2 = int(self.y2ValueEdit.text())
+        self.y1line.set_ydata([self.y1, self.y1])
+        self.y2line.set_ydata([self.y2, self.y2])
+        self.imdisplay.draw()
+        self.emit(QtCore.SIGNAL("regionChange(int,int)"), self.y1, self.y2)
 
     def nextsection(self):
-       self.nrows=int(self.nrValueEdit.text())
-       self.nsteps=int(self.nsValueEdit.text())
-       self.y1=self.y1+self.nsteps
-       self.y2=self.y1+self.nrows
-       self.y1ValueEdit.setText('%6i'%self.y1)
-       self.y2ValueEdit.setText('%6i'%self.y2)
-       self.updatesection()
+        self.nrows = int(self.nrValueEdit.text())
+        self.nsteps = int(self.nsValueEdit.text())
+        self.y1 = self.y1 + self.nsteps
+        self.y2 = self.y1 + self.nrows
+        self.y1ValueEdit.setText('%6i' % self.y1)
+        self.y2ValueEdit.setText('%6i' % self.y2)
+        self.updatesection()
+
 
 class arcWidget(QtGui.QWidget):
-    def __init__(self, arcdisplay, hmin=150, wmin=450, name=None,x1=0, w1=0, y1=None, y2=None, parent=None):
+
+    def __init__(self, arcdisplay, hmin=150, wmin=450, name=None, x1=0, w1=0, y1=None, y2=None, parent=None):
         super(arcWidget, self).__init__(parent)
-
-
 
         # Add FITS display widget with mouse interaction and overplotting
         self.arcdisplay = arcdisplay
@@ -316,59 +335,56 @@ class arcWidget(QtGui.QWidget):
         self.arcdisplay.plotArc()
 
         # Add navigation toolbars for each widget to enable zooming
-        self.toolbar=NavigationToolbar2QTAgg(self.arcdisplay.arcfigure,self)
+        self.toolbar = NavigationToolbar2QTAgg(self.arcdisplay.arcfigure, self)
 
-        #set up the information panel
-        self.infopanel=QtGui.QWidget()
+        # set up the information panel
+        self.infopanel = QtGui.QWidget()
 
-        #add the name of the file
+        # add the name of the file
         self.NameLabel = QtGui.QLabel("Filename:")
-        self.NameLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised )
+        self.NameLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised)
         self.NameValueLabel = QtGui.QLabel("%s" % name)
-        self.NameValueLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Sunken )
+        self.NameValueLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Sunken)
 
-
-        #add the rows that are extracted
+        # add the rows that are extracted
         self.y1Label = QtGui.QLabel("Y1:")
-        self.y1Label.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised )
+        self.y1Label.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised)
         self.y1ValueLabel = QtGui.QLabel("%6i" % y1)
-        self.y1ValueLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Sunken )
+        self.y1ValueLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Sunken)
         self.y2Label = QtGui.QLabel("Y2:")
-        self.y2Label.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised )
+        self.y2Label.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised)
         self.y2ValueLabel = QtGui.QLabel("%6i" % y2)
-        self.y2ValueLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Sunken )
+        self.y2ValueLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Sunken)
 
-        #add in what the value is for a x and w position
+        # add in what the value is for a x and w position
         self.x1Label = QtGui.QLabel("X1:")
-        self.x1Label.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised )
+        self.x1Label.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised)
         self.w1Label = QtGui.QLabel("w1:")
-        self.w1Label.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised )
+        self.w1Label.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised)
         self.x1ValueLabel = QtGui.QLabel("%6.2f" % x1)
-        self.x1ValueLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Sunken )
-        w1=self.arcdisplay.ws.value(x1)
+        self.x1ValueLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Sunken)
+        w1 = self.arcdisplay.ws.value(x1)
         self.w1ValueEdit = QtGui.QLineEdit("%6i" % w1)
         self.addButton = QtGui.QPushButton("Add")
         self.addButton.clicked.connect(self.addpoints)
 
-        #add in radio buttons for pixel or wavelength
+        # add in radio buttons for pixel or wavelength
         self.pixelradio = QtGui.QRadioButton("Pixel")
         self.wavelengthradio = QtGui.QRadioButton("Wavelength")
         self.pixelradio.setChecked(True)
 
-        #add in information about the order and type of solution
+        # add in information about the order and type of solution
         self.funcLabel = QtGui.QLabel("Function:")
-        self.funcLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised )
+        self.funcLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised)
         self.funcValueLabel = QtGui.QLabel("%s" % self.arcdisplay.ws.function)
-        self.funcValueLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Sunken )
+        self.funcValueLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Sunken)
         self.orderLabel = QtGui.QLabel("Order:")
-        self.orderLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised )
+        self.orderLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised)
         self.orderValueLabel = QtGui.QLabel("%2i" % self.arcdisplay.ws.order)
-        self.orderValueLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Sunken )
+        self.orderValueLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Sunken)
 
-
-     
-        #provide the full layout of the information panel
-        infoLayout=QtGui.QGridLayout(self.infopanel)
+        # provide the full layout of the information panel
+        infoLayout = QtGui.QGridLayout(self.infopanel)
         infoLayout.addWidget(self.NameLabel, 0, 0, 1, 1)
         infoLayout.addWidget(self.NameValueLabel, 0, 1, 1, 5)
         infoLayout.addWidget(self.y1Label, 1, 0, 1, 1)
@@ -398,29 +414,28 @@ class arcWidget(QtGui.QWidget):
         self.connect(self.arcdisplay, QtCore.SIGNAL('updatex(float)'), self.updatexlabel)
 
     def keyPressEvent(self, event):
-       print "Arc Widget, keyPress:", event
+        print "Arc Widget, keyPress:", event
 
     def updatexlabel(self, value):
-       try:
-           self.x1ValueLabel.setText("%6.2f" % value)
-           self.w1ValueEdit.setText("%6.2f" % self.arcdisplay.ws.value(value))
-       except TypeError:
-           pass
+        try:
+            self.x1ValueLabel.setText("%6.2f" % value)
+            self.w1ValueEdit.setText("%6.2f" % self.arcdisplay.ws.value(value))
+        except TypeError:
+            pass
 
     def addpoints(self):
-       """Add the x and w points to the list of matched points"""
-       x=float(self.x1ValueLabel.text()) 
-       w=float(self.w1ValueEdit.text())
-       #x=[1904.5, 1687.22, 3124.3499999999999, 632.57000000000005]
-       #w=[4671.2259999999997, 4624.2757000000001, 4916.5100000000002, 4383.9092000000001]
-       self.arcdisplay.addpoints(x, w)
+        """Add the x and w points to the list of matched points"""
+        x = float(self.x1ValueLabel.text())
+        w = float(self.w1ValueEdit.text())
+        #x=[1904.5, 1687.22, 3124.3499999999999, 632.57000000000005]
+        #w=[4671.2259999999997, 4624.2757000000001, 4916.5100000000002, 4383.9092000000001]
+        self.arcdisplay.addpoints(x, w)
 
 
 class errWidget(QtGui.QWidget):
-   def __init__(self, arcdisplay, hmin=150, wmin=450, name=None, parent=None):
+
+    def __init__(self, arcdisplay, hmin=150, wmin=450, name=None, parent=None):
         super(errWidget, self).__init__(parent)
-
-
 
         # Add FITS display widget with mouse interaction and overplotting
         self.arcdisplay = arcdisplay
@@ -429,30 +444,29 @@ class errWidget(QtGui.QWidget):
         self.arcdisplay.plotErr()
 
         # Add navigation toolbars for each widget to enable zooming
-        self.toolbar=NavigationToolbar2QTAgg(self.arcdisplay.errfigure,self)
+        self.toolbar = NavigationToolbar2QTAgg(self.arcdisplay.errfigure, self)
 
-        
-        #set up the information panel
-        self.infopanel=QtGui.QWidget()
+        # set up the information panel
+        self.infopanel = QtGui.QWidget()
 
-        #add the name of the file
+        # add the name of the file
         self.NameLabel = QtGui.QLabel("Filename:")
-        self.NameLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised )
+        self.NameLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised)
         self.NameValueLabel = QtGui.QLabel("%s" % name)
-        self.NameValueLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Sunken )
+        self.NameValueLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Sunken)
 
-        #add the rows that are extracted
+        # add the rows that are extracted
         self.aveLabel = QtGui.QLabel("Average:")
-        self.aveLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised )
+        self.aveLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised)
         self.aveValueLabel = QtGui.QLabel("")
-        self.aveValueLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Sunken )
+        self.aveValueLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Sunken)
         self.stdLabel = QtGui.QLabel("Std:")
-        self.stdLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised )
+        self.stdLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Raised)
         self.stdValueLabel = QtGui.QLabel("")
-        self.stdValueLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Sunken )
+        self.stdValueLabel.setFrameStyle(QtGui.QFrame.Panel | QtGui.QFrame.Sunken)
 
-        #provide the full layout of the information panel
-        infoLayout=QtGui.QGridLayout(self.infopanel)
+        # provide the full layout of the information panel
+        infoLayout = QtGui.QGridLayout(self.infopanel)
         infoLayout.addWidget(self.NameLabel, 0, 0, 1, 1)
         infoLayout.addWidget(self.NameValueLabel, 0, 1, 1, 5)
         infoLayout.addWidget(self.aveLabel, 1, 0)
@@ -469,241 +483,238 @@ class errWidget(QtGui.QWidget):
 
         self.connect(self.arcdisplay, QtCore.SIGNAL('fitUpdate()'), self.fitUpdate)
 
-   def fitUpdate(self):
-       try:
-           xp=np.array(self.arcdisplay.xp)
-           wp=np.array(self.arcdisplay.wp)
-           w=self.arcdisplay.ws.value(xp)
-           value=(wp-w).mean()
-           print value
-           self.aveValueLabel.setText("%4.2g" % value)
-           value=(wp-w).std()
-           print value
-           self.stdValueLabel.setText("%4.2g" % value)
-       except Exception, e:
-           print e
-
+    def fitUpdate(self):
+        try:
+            xp = np.array(self.arcdisplay.xp)
+            wp = np.array(self.arcdisplay.wp)
+            w = self.arcdisplay.ws.value(xp)
+            value = (wp - w).mean()
+            print value
+            self.aveValueLabel.setText("%4.2g" % value)
+            value = (wp - w).std()
+            print value
+            self.stdValueLabel.setText("%4.2g" % value)
+        except Exception as e:
+            print e
 
 
 class ArcDisplay(QtGui.QWidget):
-   """Class for displaying Arc Spectra using matplotlib and embedded in a Qt 4 GUI.
-   """
 
-   def __init__(self, xarr, farr, slines, sfluxes, ws, xp=[], wp=[], xdiff=20, 
-                res=2.0, dres=0.1, sigma=5, niter=5):
-       """Default constructor."""
-       QtGui.QWidget.__init__(self)
+    """Class for displaying Arc Spectra using matplotlib and embedded in a Qt 4 GUI.
+    """
 
-       # Initialize base class
-       self.arcfigure=MplCanvas()
-       self.errfigure=MplCanvas()
+    def __init__(self, xarr, farr, slines, sfluxes, ws, xp=[], wp=[], xdiff=20,
+                 res=2.0, dres=0.1, sigma=5, niter=5):
+        """Default constructor."""
+        QtGui.QWidget.__init__(self)
 
-       # Add central axes instance
-       self.axes = self.arcfigure.figure.add_subplot(111)
-       self.erraxes = self.errfigure.figure.add_subplot(111)
+        # Initialize base class
+        self.arcfigure = MplCanvas()
+        self.errfigure = MplCanvas()
 
-       # Connect mouse events
-       self.arcfigure.connectMatplotlibMouseMotion()
-       self.arcfigure.mpl_connect('button_press_event', self.onButtonPress)
-       self.arcfigure.mpl_connect('key_press_event', self.onKeyPress)
+        # Add central axes instance
+        self.axes = self.arcfigure.figure.add_subplot(111)
+        self.erraxes = self.errfigure.figure.add_subplot(111)
 
-       self.errfigure.connectMatplotlibMouseMotion()
-       self.errfigure.mpl_connect('button_press_event', self.onButtonPress)
-       self.errfigure.mpl_connect('key_press_event', self.onKeyPress)
- 
+        # Connect mouse events
+        self.arcfigure.connectMatplotlibMouseMotion()
+        self.arcfigure.mpl_connect('button_press_event', self.onButtonPress)
+        self.arcfigure.mpl_connect('key_press_event', self.onKeyPress)
 
-       #load the data
-       self.xarr=xarr
-       self.farr=farr
-       self.slines=slines
-       self.sfluxes=sfluxes
-       self.ws=ws
-       self.xdiff=xdiff
-       self.sigma=sigma
-       self.niter=niter
-       self.res=res  
-       self.dres=dres
+        self.errfigure.connectMatplotlibMouseMotion()
+        self.errfigure.mpl_connect('button_press_event', self.onButtonPress)
+        self.errfigure.mpl_connect('key_press_event', self.onKeyPress)
 
-       self.xp=xp
-       self.wp=wp
+        # load the data
+        self.xarr = xarr
+        self.farr = farr
+        self.slines = slines
+        self.sfluxes = sfluxes
+        self.ws = ws
+        self.xdiff = xdiff
+        self.sigma = sigma
+        self.niter = niter
+        self.res = res
+        self.dres = dres
 
-       #set up the artificial spectra
-       self.spectrum=Spectrum.Spectrum(self.slines, self.sfluxes, dw=self.dres, stype='line', sigma=self.res)
-       self.swarr=self.spectrum.wavelength
-       self.sfarr=self.spectrum.flux*self.farr.max()/self.spectrum.flux.max()
-  
-       #set up the wavelength solution
-       if self.ws.function=='line':
-          self.ws.set_xarr(self.xarr)
-          self.ws.farr=self.farr
-          self.ws.spectrum=self.spectrum
-          
-          
+        self.xp = xp
+        self.wp = wp
 
-       #set up the list of deleted points
-       self.dxp=[]
-       self.dwp=[]
+        # set up the artificial spectra
+        self.spectrum = Spectrum.Spectrum(self.slines, self.sfluxes, dw=self.dres, stype='line', sigma=self.res)
+        self.swarr = self.spectrum.wavelength
+        self.sfarr = self.spectrum.flux * self.farr.max() / self.spectrum.flux.max()
 
-       #set up other variables
-       self.isArt=False
-       self.isFeature=False
+        # set up the wavelength solution
+        if self.ws.function == 'line':
+            self.ws.set_xarr(self.xarr)
+            self.ws.farr = self.farr
+            self.ws.spectrum = self.spectrum
 
-       # Set display parameters
-       self.xmin=self.xarr.min()
-       self.xmax=self.xarr.max()
-       self.ymin=self.farr.min()
-       self.ymax=self.farr.max()
+        # set up the list of deleted points
+        self.dxp = []
+        self.dwp = []
 
-   def onKeyPress(self, event):
-       """Emit signal on key press"""
-       if event.key=='?':
-           #return the help file
-           print '?:', event.key
-       elif event.key=='c':
-           #return the centroid
-           if event.xdata:
-               cx=st.mcentroid(self.xarr, self.farr, xc=event.xdata, xdiff=self.xdiff)
-               self.emit(QtCore.SIGNAL("updatex(float)"), cx)
-       elif event.key=='x':
-           #return the x position
-           if event.xdata:
-               self.emit(QtCore.SIGNAL("updatex(float)"), event.xdata)
-       elif event.key=='f':
-           #find the fit
-           self.findfit()
-           self.emit(QtCore.SIGNAL("fitUpdate()"))
-       elif event.key=='b':
-           #auto-idenitfy features
-           self.findfeatures()
-       elif event.key=='z':
-           #Assume the solution is correct and find the zeropoint
-           #that best matches it from cross correllation
-           self.findzp()
-       elif event.key=='e':
-           #find closest feature from existing fit and line list
-           #and match it
-           pass
-       elif event.key=='l':
-           #plot the features from existing list
-           self.plotFeatures()
-           self.redraw_canvas()
-       elif event.key=='i':
-           #reset identified features
-           pass
-       elif event.key=='r':
-           #redraw graph
-           self.redraw_canvas()
-       elif event.key=='a':
-           #draw artificial spectrum
-           self.isArt= not self.isArt
-           self.redraw_canvas()
-       elif event.key=='d':
-           #Delete feature 
-           save=False
-           if event.canvas==self.errfigure: save=True
-           self.deletepoints(event.xdata, save=save)
-           self.redraw_canvas(keepzoom=True)
-       elif event.key:
-           self.emit(QtCore.SIGNAL("keyPressEvent(string)"), event.key)
+        # set up other variables
+        self.isArt = False
+        self.isFeature = False
 
-   def onButtonPress(self, event):
-       """Emit signal on selecting valid image position."""
+        # Set display parameters
+        self.xmin = self.xarr.min()
+        self.xmax = self.xarr.max()
+        self.ymin = self.farr.min()
+        self.ymax = self.farr.max()
 
-       if event.xdata and event.ydata:
-           print event.xdata, event.ydata, event.canvas, event.name
-           self.emit(QtCore.SIGNAL("positionSelected(float, float)"),
-                    float(event.xdata), float(event.ydata))
+    def onKeyPress(self, event):
+        """Emit signal on key press"""
+        if event.key == '?':
+            # return the help file
+            print '?:', event.key
+        elif event.key == 'c':
+            # return the centroid
+            if event.xdata:
+                cx = st.mcentroid(self.xarr, self.farr, xc=event.xdata, xdiff=self.xdiff)
+                self.emit(QtCore.SIGNAL("updatex(float)"), cx)
+        elif event.key == 'x':
+            # return the x position
+            if event.xdata:
+                self.emit(QtCore.SIGNAL("updatex(float)"), event.xdata)
+        elif event.key == 'f':
+            # find the fit
+            self.findfit()
+            self.emit(QtCore.SIGNAL("fitUpdate()"))
+        elif event.key == 'b':
+            # auto-idenitfy features
+            self.findfeatures()
+        elif event.key == 'z':
+            # Assume the solution is correct and find the zeropoint
+            # that best matches it from cross correllation
+            self.findzp()
+        elif event.key == 'e':
+            # find closest feature from existing fit and line list
+            # and match it
+            pass
+        elif event.key == 'l':
+            # plot the features from existing list
+            self.plotFeatures()
+            self.redraw_canvas()
+        elif event.key == 'i':
+            # reset identified features
+            pass
+        elif event.key == 'r':
+            # redraw graph
+            self.redraw_canvas()
+        elif event.key == 'a':
+            # draw artificial spectrum
+            self.isArt = not self.isArt
+            self.redraw_canvas()
+        elif event.key == 'd':
+            # Delete feature
+            save = False
+            if event.canvas == self.errfigure:
+                save = True
+            self.deletepoints(event.xdata, save=save)
+            self.redraw_canvas(keepzoom=True)
+        elif event.key:
+            self.emit(QtCore.SIGNAL("keyPressEvent(string)"), event.key)
 
-   def plotArc(self):
+    def onButtonPress(self, event):
+        """Emit signal on selecting valid image position."""
+
+        if event.xdata and event.ydata:
+            print event.xdata, event.ydata, event.canvas, event.name
+            self.emit(QtCore.SIGNAL("positionSelected(float, float)"),
+                      float(event.xdata), float(event.ydata))
+
+    def plotArc(self):
         """Draw image to canvas."""
 
         # plot the spectra
-        self.spcurve,=self.axes.plot(self.xarr,self.farr,linewidth=0.5,linestyle='-',marker=None,color='b')
+        self.spcurve, = self.axes.plot(self.xarr, self.farr, linewidth=0.5, linestyle='-', marker=None, color='b')
 
-   def plotArt(self):
-       """Plot the artificial spectrum"""
-       self.isArt=True
-       warr=self.ws.value(self.xarr)
-       asfarr=st.interpolate(warr, self.swarr, self.sfarr, left=0.0, right=0.0)
-       self.fpcurve,=self.axes.plot(self.xarr,asfarr,linewidth=0.5,linestyle='-',
-                                marker=None,color='r')
+    def plotArt(self):
+        """Plot the artificial spectrum"""
+        self.isArt = True
+        warr = self.ws.value(self.xarr)
+        asfarr = st.interpolate(warr, self.swarr, self.sfarr, left=0.0, right=0.0)
+        self.fpcurve, = self.axes.plot(self.xarr, asfarr, linewidth=0.5, linestyle='-',
+                                       marker=None, color='r')
 
-   def plotFeatures(self):
-       """Plot features identified in the line list"""
-       self.isFeature=True
-       fl=np.array(self.xp)*0.0+0.25*self.farr.max()
-       self.splines=self.axes.plot(self.xp, fl , ls='', marker='|', ms=20, color='#00FF00')
-       #set up the text position
-       tsize=0.83
-       self.ymin, self.ymax = self.axes.get_ylim()
-       ppp=(self.ymax-self.ymin)/(self.arcfigure.figure.get_figheight()*self.arcfigure.figure.get_dpi())
-       f=self.ymax-10*tsize*ppp
-       for x,w in zip(self.xp, self.wp):
-           w='%6.2f' % float(w)
-           self.axes.text(x, f, w, size='small', rotation='vertical', color='#00FF00') 
+    def plotFeatures(self):
+        """Plot features identified in the line list"""
+        self.isFeature = True
+        fl = np.array(self.xp) * 0.0 + 0.25 * self.farr.max()
+        self.splines = self.axes.plot(self.xp, fl, ls='', marker='|', ms=20, color='#00FF00')
+        # set up the text position
+        tsize = 0.83
+        self.ymin, self.ymax = self.axes.get_ylim()
+        ppp = (self.ymax - self.ymin) / (self.arcfigure.figure.get_figheight() * self.arcfigure.figure.get_dpi())
+        f = self.ymax - 10 * tsize * ppp
+        for x, w in zip(self.xp, self.wp):
+            w = '%6.2f' % float(w)
+            self.axes.text(x, f, w, size='small', rotation='vertical', color='#00FF00')
 
-   def plotErr(self):
-       """Draw image to canvas."""
-       if self.xp and self.wp:
-           # plot the spectra
-           w=self.ws.value(self.xp)
-           self.errcurve,=self.erraxes.plot(self.xp,self.wp-w,linewidth=0.5,linestyle='',marker='o',color='b')
-       if self.dxp and self.dwp:
-           # plot the spectra
-           dw=self.ws.value(self.dxp)
-           self.delerrcurve,=self.erraxes.plot(self.dxp,self.dwp-dw,linewidth=0.5,linestyle='',marker='x',color='b')
+    def plotErr(self):
+        """Draw image to canvas."""
+        if self.xp and self.wp:
+            # plot the spectra
+            w = self.ws.value(self.xp)
+            self.errcurve, = self.erraxes.plot(self.xp, self.wp - w, linewidth=0.5, linestyle='', marker='o', color='b')
+        if self.dxp and self.dwp:
+            # plot the spectra
+            dw = self.ws.value(self.dxp)
+            self.delerrcurve, = self.erraxes.plot(
+                self.dxp, self.dwp - dw, linewidth=0.5, linestyle='', marker='x', color='b')
 
-   def findfeatures(self):
-       """Given a set of features, find other features that might 
-          correspond to those features
-       """
-       xp, wp=st.findfeatures(self.xarr, self.farr, self.slines, self.sfluxes,
-                              self.ws, sigma=self.sigma, niter=self.niter)
-       for x, w in zip(xp, wp):
-          if w not in self.wp and w>-1: 
-             self.xp.append(x)
-             self.wp.append(w)
-       self.plotFeatures()
-       self.redraw_canvas()
-         
+    def findfeatures(self):
+        """Given a set of features, find other features that might
+           correspond to those features
+        """
+        xp, wp = st.findfeatures(self.xarr, self.farr, self.slines, self.sfluxes,
+                                 self.ws, sigma=self.sigma, niter=self.niter)
+        for x, w in zip(xp, wp):
+            if w not in self.wp and w > -1:
+                self.xp.append(x)
+                self.wp.append(w)
+        self.plotFeatures()
+        self.redraw_canvas()
 
-   def findzp(self):
-       """Find the zeropoint for the source and plot of the new value
-       """
-       self.ws=st.findzeropoint(self.xarr, self.farr, self.swarr, self.sfarr, 
-                                self.ws, dc=10, nstep=20, inttype='interp')
-       self.plotArt()
-       self.redraw_canvas()
+    def findzp(self):
+        """Find the zeropoint for the source and plot of the new value
+        """
+        self.ws = st.findzeropoint(self.xarr, self.farr, self.swarr, self.sfarr,
+                                   self.ws, dc=10, nstep=20, inttype='interp')
+        self.plotArt()
+        self.redraw_canvas()
 
-   def findfit(self):
-       print self.xp
-       print self.wp
-       self.ws=st.findfit(self.xp, self.wp, function=self.ws.function, order=self.ws.order)
-       self.err_redraw_canvas()
+    def findfit(self):
+        print self.xp
+        print self.wp
+        self.ws = st.findfit(self.xp, self.wp, function=self.ws.function, order=self.ws.order)
+        self.err_redraw_canvas()
 
-   def addpoints(self, x, w):
-       """Add points to the line list
-       """
-       if isinstance(x, list) and isinstance(w, list):
-           self.xp.extend(x)
-           self.wp.extend(w)
-       else:
-           self.xp.append(x)
-           self.wp.append(w)
-       print self.xp
+    def addpoints(self, x, w):
+        """Add points to the line list
+        """
+        if isinstance(x, list) and isinstance(w, list):
+            self.xp.extend(x)
+            self.wp.extend(w)
+        else:
+            self.xp.append(x)
+            self.wp.append(w)
+        print self.xp
 
-   def deletepoints(self, x, save=False):
-       """ Delete points from the line list
-       """
-       in_minw=np.abs(np.array(self.xp)-x).argmin()
-       if save:
-           self.dxp.append(self.xp[in_minw])
-           self.dwp.append(self.wp[in_minw])
-       self.xp.__delitem__(in_minw)
-       self.wp.__delitem__(in_minw)
+    def deletepoints(self, x, save=False):
+        """ Delete points from the line list
+        """
+        in_minw = np.abs(np.array(self.xp) - x).argmin()
+        if save:
+            self.dxp.append(self.xp[in_minw])
+            self.dwp.append(self.wp[in_minw])
+        self.xp.__delitem__(in_minw)
+        self.wp.__delitem__(in_minw)
 
- 
-   def redraw_canvas(self,keepzoom=False):
+    def redraw_canvas(self, keepzoom=False):
         if keepzoom:
             # Store current zoom level
             xmin, xmax = self.axes.get_xlim()
@@ -715,25 +726,25 @@ class ArcDisplay(QtGui.QWidget):
         # Draw image
         self.plotArc()
 
-        #if necessary, redraw the features 
+        # if necessary, redraw the features
         if self.isFeature:
-           self.plotFeatures()
+            self.plotFeatures()
 
-        #if necessary, draw the artificial spectrum
+        # if necessary, draw the artificial spectrum
         if self.isArt:
-           self.plotArt()
+            self.plotArt()
 
         # Restore zoom level
         if keepzoom:
-           self.axes.set_xlim((self.xmin,self.xmax))
-           self.axes.set_ylim((self.ymin,self.ymax))
+            self.axes.set_xlim((self.xmin, self.xmax))
+            self.axes.set_ylim((self.ymin, self.ymax))
 
         # Force redraw
         self.arcfigure.draw()
 
         self.err_redraw_canvas()
 
-   def err_redraw_canvas(self,keepzoom=False):
+    def err_redraw_canvas(self, keepzoom=False):
         if keepzoom:
             # Store current zoom level
             xmin, xmax = self.erraxes.get_xlim()
@@ -749,34 +760,38 @@ class ArcDisplay(QtGui.QWidget):
 
         # Restore zoom level
         if keepzoom:
-           self.erraxes.set_xlim((xmin,xmax))
-           self.erraxes.set_ylim((ymin,ymax))
+            self.erraxes.set_xlim((xmin, xmax))
+            self.erraxes.set_ylim((ymin, ymax))
         else:
-           self.erraxes.set_xlim((self.xmin,self.xmax))
- 
+            self.erraxes.set_xlim((self.xmin, self.xmax))
+
         self.errfigure.draw()
 
         self.emit(QtCore.SIGNAL("fitUpdate()"))
- 
- 
-   
 
-def InterIdentify(xarr, specarr, slines, sfluxes, ws, xdiff=20, function='poly', \
+
+def InterIdentify(xarr, specarr, slines, sfluxes, ws, xdiff=20, function='poly',
                   filename=None, order=3, scale='zscale', cmap='gray', contrast=1.0, verbose=True):
 
-  
-        
-   # Create GUI
-   App = QtGui.QApplication(sys.argv)
-   aw = InterIdentifyWindow(xarr, specarr, slines, sfluxes, ws,  cmap=cmap, scale=scale, contrast=contrast, filename=filename)
-   aw.show()
+    # Create GUI
+    App = QtGui.QApplication(sys.argv)
+    aw = InterIdentifyWindow(
+        xarr,
+        specarr,
+        slines,
+        sfluxes,
+        ws,
+        cmap=cmap,
+        scale=scale,
+        contrast=contrast,
+        filename=filename)
+    aw.show()
 
-   # Start application event loop
-   exit=App.exec_()
+    # Start application event loop
+    exit = App.exec_()
 
-   # Check if GUI was executed succesfully
-   if exit!=0:
-        raise SALTSpecError('InterIdentify GUI has unexpected exit status '+str(exit))
+    # Check if GUI was executed succesfully
+    if exit != 0:
+        raise SALTSpecError('InterIdentify GUI has unexpected exit status ' + str(exit))
 
-   return aw.ImageSolution
-
+    return aw.ImageSolution

--- a/PySpectrograph/Identify/__init__.py
+++ b/PySpectrograph/Identify/__init__.py
@@ -1,5 +1,5 @@
-"""Identify is a set of tasks that provide fitting and determine the 
+"""Identify is a set of tasks that provide fitting and determine the
 wavelength calibration of a set of data
 """
 
-import Identify
+from . import Identify

--- a/PySpectrograph/Identify/specidentify.py
+++ b/PySpectrograph/Identify/specidentify.py
@@ -31,7 +31,7 @@
 # POSSIBILITY OF SUCH DAMAGE.                                              #
 ############################################################################
 """
-SPECIDENTIFY  is a program to read in SALT RSS spectroscopic arc lamps and 
+SPECIDENTIFY  is a program to read in SALT RSS spectroscopic arc lamps and
 determine the wavelength solution for that data.  The input data should be
 a SALT arc lamp and a line list or another arc lamp image with high quality
 wavelength solution. The lamp list can be either wavelengths, wavelengths
@@ -39,9 +39,9 @@ and fluxes, or an arc image with a high quality solution.  The line lamp
 can also be left unspecified and the user will manually enter the data.
 
 From there, the user has several different possible choices.  They can provide
-a first guess of the coefficients for the wavelength solution or transformation, 
-indicate the model for the spectragraph for the first guess, or provide an 
-image with a solution already as the first guess.  
+a first guess of the coefficients for the wavelength solution or transformation,
+indicate the model for the spectragraph for the first guess, or provide an
+image with a solution already as the first guess.
 
 Author                 Version      Date
 -----------------------------------------------
@@ -53,19 +53,22 @@ TODO
 
 LIMITATIONS
 -----------
-1. Currently assumes that the linelist is of the form of an ascii file with 
+1. Currently assumes that the linelist is of the form of an ascii file with
    either appropriate information in either one or two columns
 
 """
 # Ensure python 2.5 compatibility
 from __future__ import with_statement
 
-import os, sys
+import os
+import sys
 import time
 import numpy as np
 
-from pyraf import iraf 
-import saltprint, saltio, saltkey
+from pyraf import iraf
+import saltprint
+import saltio
+import saltkey
 import saltsafekey
 import saltsafeio
 from saltsafelog import logging
@@ -79,217 +82,208 @@ from PySpectrograph import LineSolution
 from PySpectrograph.detectlines import detectlines
 
 
-import spectools as st
-from spectools import SALTSpecError
-from InterIdentify import InterIdentify
-from AutoIdentify import AutoIdentify
+from . import spectools as st
+from .spectools import SALTSpecError
+from .InterIdentify import InterIdentify
+from .AutoIdentify import AutoIdentify
 
-debug=True
-
+debug = True
 
 
 # -----------------------------------------------------------
 # core routine
 
-def specidentify(images,linelist, outfile, guesstype, guessfile, function, \
-                 order, rstep, interact, clobber,logfile,verbose,status):
+def specidentify(images, linelist, outfile, guesstype, guessfile, function,
+                 order, rstep, interact, clobber, logfile, verbose, status):
 
-   with logging(logfile,debug) as log:
+    with logging(logfile, debug) as log:
 
-       #set up the variables
-       infiles = []
-       outfiles = []
-       status = 0
+        # set up the variables
+        infiles = []
+        outfiles = []
+        status = 0
 
-       # Check the input images 
-       infiles = saltsafeio.argunpack ('Input',images)
-       print infiles
+        # Check the input images
+        infiles = saltsafeio.argunpack('Input', images)
+        print infiles
 
-       # create list of output files 
-       outfiles = saltsafeio.argunpack ('Input',outfile)
+        # create list of output files
+        outfiles = saltsafeio.argunpack('Input', outfile)
 
-       #if outfiles is a single image, turn it into a list 
-       #of the same length as infiles
-       if len(outfiles)!=len(infiles):
-          if len(outfiles)==1:
-               outfiles=outfiles*len(infiles)
-          elif len(outfiles)==0:
-               outfiles=[None]*len(infiles)
-          else:
-               msg='Please enter an appropriate number of outfiles'
-               raise SALTSpecError(msg)
+        # if outfiles is a single image, turn it into a list
+        # of the same length as infiles
+        if len(outfiles) != len(infiles):
+            if len(outfiles) == 1:
+                outfiles = outfiles * len(infiles)
+            elif len(outfiles) == 0:
+                outfiles = [None] * len(infiles)
+            else:
+                msg = 'Please enter an appropriate number of outfiles'
+                raise SALTSpecError(msg)
 
-       # open the line lists
-       slines, sfluxes = st.readlinelist(linelist)
+        # open the line lists
+        slines, sfluxes = st.readlinelist(linelist)
 
-       # Identify the lines in each file
-       for img, oimg in zip(infiles, outfiles):
-           log.message('Proccessing image %s' % img)
-           identify(img, oimg, slines, sfluxes, guesstype, guessfile, function, 
-                    order, rstep, interact, clobber, log, verbose)
-
+        # Identify the lines in each file
+        for img, oimg in zip(infiles, outfiles):
+            log.message('Proccessing image %s' % img)
+            identify(img, oimg, slines, sfluxes, guesstype, guessfile, function,
+                     order, rstep, interact, clobber, log, verbose)
 
 
 #------------------------------------------------------------------
 # Find the solution for lines in a file
 
-def identify(img, oimg, slines, sfluxes, guesstype, guessfile, function, order,  
-             rstep, interact, clobber,log,  verbose):
-   """For a given image, find the solution for each row in the file.  Use the appropriate first guess and 
-      guess type along with the appropriate function and order for the fit.
+def identify(img, oimg, slines, sfluxes, guesstype, guessfile, function, order,
+             rstep, interact, clobber, log, verbose):
+    """For a given image, find the solution for each row in the file.  Use the appropriate first guess and
+       guess type along with the appropriate function and order for the fit.
 
-      Write out the new image with the solution in the headers and/or as a table in the multi-extension
-      fits file
+       Write out the new image with the solution in the headers and/or as a table in the multi-extension
+       fits file
 
-       returns the status
-   """
-   status=0
-   ImageSolution={}
-   dcstep=3
-   nstep=50 
-   res=2.0
-   dres=0.1
-   centerrow=None
-   nrows=1
-   sigma=3
-   niter=5
-   xdiff=2*res
-   method='MatchZero'
+        returns the status
+    """
+    status = 0
+    ImageSolution = {}
+    dcstep = 3
+    nstep = 50
+    res = 2.0
+    dres = 0.1
+    centerrow = None
+    nrows = 1
+    sigma = 3
+    niter = 5
+    xdiff = 2 * res
+    method = 'MatchZero'
 
-   #Open up the image
-   hdu=saltsafeio.openfits(img)   
+    # Open up the image
+    hdu = saltsafeio.openfits(img)
 
-   #Read in important keywords
+    # Read in important keywords
 
-   #determine the central row and read it in
-   try:
-       data=hdu[1].data
-       midline=int(0.5*len(data))
-       xarr=np.arange(len(data[midline]))
-       specarr=data
-   except Exception, e:
-       message = 'Unable to read in data array in %s because %s' % (img, e)
-       raise SALTSpecError(message)
+    # determine the central row and read it in
+    try:
+        data = hdu[1].data
+        midline = int(0.5 * len(data))
+        xarr = np.arange(len(data[midline]))
+        specarr = data
+    except Exception as e:
+        message = 'Unable to read in data array in %s because %s' % (img, e)
+        raise SALTSpecError(message)
 
+    # determine the type of first guess.  Assumes none
+    if guesstype == 'user':
+        pass
+    elif guesstype == 'rss':
+        dateobs = saltsafekey.get('DATE-OBS', hdu[0], img)
+        utctime = saltsafekey.get('UTC-OBS', hdu[0], img)
+        instrume = saltsafekey.get('INSTRUME', hdu[0], img)
+        grating = saltsafekey.get('GRATING', hdu[0], img)
+        grang = saltsafekey.get('GR-ANGLE', hdu[0], img)
+        arang = saltsafekey.get('AR-ANGLE', hdu[0], img)
+        filter = saltsafekey.get('FILTER', hdu[0], img)
+        slit = float(saltsafekey.get('MASKID', hdu[0], img))
+        xbin, ybin = saltsafekey.ccdbin(hdu[0], img)
+        # set up the rss model
+        rssmodel = RSSModel.RSSModel(grating_name=grating.strip(), gratang=grang,
+                                     camang=arang, slit=slit, xbin=xbin, ybin=ybin)
+        rss = rssmodel.rss
+        res = 1e7 * rss.calc_resolelement(rss.gratang, rss.gratang - rss.camang)
 
-   #determine the type of first guess.  Assumes none 
-   if guesstype=='user':
-       pass
-   elif guesstype=='rss':
-       dateobs=saltsafekey.get('DATE-OBS', hdu[0], img)
-       utctime=saltsafekey.get('UTC-OBS', hdu[0], img)
-       instrume=saltsafekey.get('INSTRUME', hdu[0], img)
-       grating=saltsafekey.get('GRATING', hdu[0], img)
-       grang=saltsafekey.get('GR-ANGLE', hdu[0], img)
-       arang=saltsafekey.get('AR-ANGLE', hdu[0], img)
-       filter=saltsafekey.get('FILTER', hdu[0], img)
-       slit=float(saltsafekey.get('MASKID', hdu[0], img))
-       xbin, ybin = saltsafekey.ccdbin( hdu[0], img)
-       #set up the rss model
-       rssmodel=RSSModel.RSSModel(grating_name=grating.strip(), gratang=grang, \
-                              camang=arang,slit=slit, xbin=xbin, ybin=ybin)
-       rss=rssmodel.rss
-       res=1e7*rss.calc_resolelement(rss.gratang, rss.gratang-rss.camang)
+        if not instrume in ['PFIS', 'RSS']:
+            msg = '%s is not a currently supported instrument' % instrume
+            raise SALTSpecError(msg)
+        ws = useRSSModel(xarr, rss, function=function, order=order)
+    elif guesstype == 'image':
+        pass
+    else:
+        ws = None
 
-       if not instrume in ['PFIS', 'RSS']:
-           msg='%s is not a currently supported instrument' % instrume
-           raise SALTSpecError(msg)
-       ws=useRSSModel(xarr, rss, function=function, order=order)
-   elif guesstype=='image':
-      pass
-   else:
-      ws=None
+    # run in either interactive or non-interactive mode
+    if interact:
+        ImageSolution = InterIdentify(xarr, specarr, slines, sfluxes, ws, xdiff=xdiff, function=function,
+                                      order=order, verbose=True)
+    else:
+        ImageSolution = AutoIdentify(xarr, specarr, slines, sfluxes, ws,
+                                     rstep=rstep, method=method, icenter=centerrow, nrows=nrows,
+                                     res=res, dres=dres, dc=dcstep, nstep=nstep, sigma=sigma, niter=niter,
+                                     verbose=verbose)
 
+    # set up the list of solutions to into an array
+    key_arr = np.array(ImageSolution.keys())
+    arg_arr = key_arr.argsort()
+    ws_arr = np.zeros((len(arg_arr), len(ws.coef) + 1), dtype=float)
 
-   #run in either interactive or non-interactive mode
-   if interact:
-       ImageSolution=InterIdentify(xarr, specarr, slines, sfluxes, ws, xdiff=xdiff, function=function, \
-                           order=order, verbose=True)
-   else:
-       ImageSolution = AutoIdentify(xarr, specarr, slines, sfluxes, ws,  \
-                         rstep=rstep, method=method, icenter=centerrow, nrows=nrows, \
-                         res=res, dres=dres, dc=dcstep, nstep=nstep, sigma=sigma, niter=niter, \
-                         verbose=verbose)
+    # write the solution to an array
+    for j, i in enumerate(arg_arr):
+        if isinstance(ImageSolution[key_arr[i]], WavelengthSolution.WavelengthSolution):
+            ws_arr[j, 0] = key_arr[i]
+            ws_arr[j, 1:] = ImageSolution[key_arr[i]].coef
 
+    # write the solution as an file
+    if outfile:
+        # write header to the file that should include the order and function
+        if os.path.isfile(outfile) and not clobber:
+            dout = open(outfile, 'a')
+        else:
+            dout = open(outfile, 'w')
 
-   #set up the list of solutions to into an array
-   key_arr=np.array(ImageSolution.keys())
-   arg_arr=key_arr.argsort()
-   ws_arr=np.zeros((len(arg_arr),len(ws.coef)+1), dtype=float)
+        msg = '#WS: Wavelength solution for image %s\n' % img
+        msg += '#The following parameters were used in determining the solution:\n'
+        msg += '#name=%s\n' % img
+        msg += '#time-obs=%s %s\n' % (dateobs, utctime)
+        msg += '#instrument=%s\n' % instrume
+        msg += '#grating=%s\n' % grating.strip()
+        msg += '#graang=%s\n' % grang
+        msg += '#arang=%s\n' % arang
+        msg += '#filter=%s\n' % filter.strip()
+        msg += '#Function=%s\n' % function
+        msg += '#Order=%s\n' % order
+        msg += '#Starting Data\n'
+        dout.write(msg)
 
-   #write the solution to an array 
-   for j,i in enumerate(arg_arr):
-      if  isinstance(ImageSolution[key_arr[i]], WavelengthSolution.WavelengthSolution):
-          ws_arr[j,0]=key_arr[i]
-          ws_arr[j,1:]=ImageSolution[key_arr[i]].coef
+        for i in range(len(ws_arr)):
+            if ws_arr[i, 0]:
+                msg = '%5.2f ' % ws_arr[i, 0]
+                msg += ' '.join(['%e' % k for k in ws_arr[i, 1:]])
+                dout.write(msg + '\n')
+        dout.write('\n')
+        dout.close()
 
-   #write the solution as an file 
-   if outfile:
-       #write header to the file that should include the order and function
-       if os.path.isfile(outfile) and not clobber:
-          dout=open(outfile, 'a')
-       else:
-          dout=open(outfile, 'w')
+    # write the solution as an extension
+    hdu.close()
 
-       msg='#WS: Wavelength solution for image %s\n' % img
-       msg+= '#The following parameters were used in determining the solution:\n'
-       msg+= '#name=%s\n' % img 
-       msg+= '#time-obs=%s %s\n' % (dateobs, utctime )
-       msg+= '#instrument=%s\n' % instrume
-       msg+= '#grating=%s\n' % grating.strip()
-       msg+= '#graang=%s\n' % grang   
-       msg+= '#arang=%s\n' % arang 
-       msg+= '#filter=%s\n' % filter.strip() 
-       msg+= '#Function=%s\n' % function
-       msg+= '#Order=%s\n' % order
-       msg+= '#Starting Data\n'
-       dout.write(msg)
-
-       for i in range(len(ws_arr)):
-           if ws_arr[i,0]:
-               msg = '%5.2f ' % ws_arr[i,0]
-               msg +=' '.join(['%e' % k for k in ws_arr[i,1:]])
-               dout.write(msg+'\n')
-       dout.write('\n')
-       dout.close()
-          
-
-   #write the solution as an extension
-   hdu.close()
-
-   return 
-
+    return
 
 
 def useRSSModel(xarr, rss, function='poly', order=3):
-   """Returns the wavelength solution using the RSS model for the spectrograph
-     
-
-   """
-
-   
-   #now for each position on the detector, calculate the wavelength at that position
-   if function=='poly' or function=='legendre':
-       d=rss.detector.xbin*rss.detector.pix_size*(xarr-0.5*len(xarr))
-       alpha=rss.gratang
-       beta=rss.gratang-rss.camang
-       dbeta=-np.degrees(np.arctan(d/rss.camera.focallength))
-       y=1e7*rss.calc_wavelength(alpha, beta+dbeta)
-
-       #for these models, calculate the wavelength solution
-       ws=WavelengthSolution.WavelengthSolution(xarr, y, order=order, function=function)
-       ws.fit()
-   elif function=='line':
-       ws=LineSolution.LineSolution(rss)
-   else:
-       message='%s is not an acceptable form for the function' % function
-       raise SALTSpecError(message)
-
-   return ws
+    """Returns the wavelength solution using the RSS model for the spectrograph
 
 
+    """
 
-# main code 
+    # now for each position on the detector, calculate the wavelength at that position
+    if function == 'poly' or function == 'legendre':
+        d = rss.detector.xbin * rss.detector.pix_size * (xarr - 0.5 * len(xarr))
+        alpha = rss.gratang
+        beta = rss.gratang - rss.camang
+        dbeta = -np.degrees(np.arctan(d / rss.camera.focallength))
+        y = 1e7 * rss.calc_wavelength(alpha, beta + dbeta)
 
-parfile = iraf.osfn("saltspec$specidentify.par") 
-t = iraf.IrafTaskFactory(taskname="specidentify",value=parfile,function=specidentify, pkgname='saltspec')
+        # for these models, calculate the wavelength solution
+        ws = WavelengthSolution.WavelengthSolution(xarr, y, order=order, function=function)
+        ws.fit()
+    elif function == 'line':
+        ws = LineSolution.LineSolution(rss)
+    else:
+        message = '%s is not an acceptable form for the function' % function
+        raise SALTSpecError(message)
+
+    return ws
+
+
+# main code
+
+parfile = iraf.osfn("saltspec$specidentify.par")
+t = iraf.IrafTaskFactory(taskname="specidentify", value=parfile, function=specidentify, pkgname='saltspec')

--- a/PySpectrograph/Identify/spectools.py
+++ b/PySpectrograph/Identify/spectools.py
@@ -17,8 +17,12 @@ LIMITATIONS
 import pyfits
 import numpy as np
 from scipy import interpolate as scint
-from pyraf import iraf 
-import saltprint, saltkey, saltio, salttime, saltstat
+from pyraf import iraf
+import saltprint
+import saltkey
+import saltio
+import salttime
+import saltstat
 import saltsafekey
 import saltsafeio
 import slottool
@@ -30,79 +34,88 @@ from PySpectrograph.detectlines import detectlines, centroid
 from PySpectrograph.Spectrum import Spectrum
 from PySpectrograph.apext import apext
 
+
 class SALTSpecError(SaltError):
+
     """Errors involving Spec package should cause this exception to be raised."""
     pass
 
 
-default_kernal=[0, -1, -2, -3, -2, -1, 0, 1, 2, 3, 2, 1, 0 ]
+default_kernal = [0, -1, -2, -3, -2, -1, 0, 1, 2, 3, 2, 1, 0]
+
 
 def mcentroid(xarr, yarr, kern=default_kernal, xc=None, xdiff=None, mode='same'):
     """Find the centroid of a line following a similar algorithm as
        the centroid algorithm in IRAF.   xarr and yarr should be an area
        around the desired feature to be centroided.  The default kernal
-       is used if the user does not specific one. 
+       is used if the user does not specific one.
 
-       The algorithm solves for the solution to the equation 
+       The algorithm solves for the solution to the equation
 
        ..math:: \int (I-I_0) f(x-x_0) dx = 0
 
        returns xc
     """
-    if xdiff<len(kern): xdiff=len(kern)
+    if xdiff < len(kern):
+        xdiff = len(kern)
     if xc and xdiff:
-       mask=(abs(xarr-xc)<xdiff)
+        mask = (abs(xarr - xc) < xdiff)
     else:
-       mask=np.ones(len(xarr))
+        mask = np.ones(len(xarr))
 
     return centroid(xarr, yarr, kern=kern, mask=mask, mode=mode)
 
+
 def interpolate(x, x_arr, y_arr, type='interp', order=3, left=None, right=None):
-   """Perform interpolation on value x using arrays x_arr
-      and y_arr.  The type of interpolate is defined by interp
-  
-      type: 
-      interp--use numpy.interp
-      spline--use scipy.splrep and splev
+    """Perform interpolation on value x using arrays x_arr
+       and y_arr.  The type of interpolate is defined by interp
 
-      return
-   """
-   if type=='interp':
-      y=np.interp(x, x_arr, y_arr, left=left, right=right)
-   if type=='spline':
-      if not left==None: y_arr[0]=left
-      if not right==None: y_arr[-1]=right
+       type:
+       interp--use numpy.interp
+       spline--use scipy.splrep and splev
 
-      tk=scint.splrep(x_arr, y_arr, k=order)
-      y=scint.splev(x, tk, der=0)
+       return
+    """
+    if type == 'interp':
+        y = np.interp(x, x_arr, y_arr, left=left, right=right)
+    if type == 'spline':
+        if not left is None:
+            y_arr[0] = left
+        if not right is None:
+            y_arr[-1] = right
 
-   return y
+        tk = scint.splrep(x_arr, y_arr, k=order)
+        y = scint.splev(x, tk, der=0)
+
+    return y
+
 
 def clipstats(yarr, thresh, iter):
     """Return sigma-clipped mean of yarr"""
-    mean=yarr.mean()
-    std=yarr.std()
+    mean = yarr.mean()
+    std = yarr.std()
     for i in range(iter):
-        mask=(abs(yarr-mean)<thresh*std)
-        mean=yarr[mask].mean()
-        std=yarr[mask].std()
-        
+        mask = (abs(yarr - mean) < thresh * std)
+        mean = yarr[mask].mean()
+        std = yarr[mask].std()
+
     return mean, std
 
+
 def findpoints(xarr, farr, sigma, niter):
-   """Find all the peaks and the peak flux in a spectrum"""
-   xp=detectlines(xarr, farr, sigma=sigma, niter=niter)
-   print xp 
-   mask=[(xp==k).any() for k in xarr]
-   xf=np.compress(mask, farr)
-   #repeat the second time, but get the centroids for the points
-   xp=detectlines(xarr, farr, sigma=sigma, niter=niter, center=True)
-   print xp
-   return xp, xf
+    """Find all the peaks and the peak flux in a spectrum"""
+    xp = detectlines(xarr, farr, sigma=sigma, niter=niter)
+    print xp
+    mask = [(xp == k).any() for k in xarr]
+    xf = np.compress(mask, farr)
+    # repeat the second time, but get the centroids for the points
+    xp = detectlines(xarr, farr, sigma=sigma, niter=niter, center=True)
+    print xp
+    return xp, xf
 
 
 def flatspectrum(xarr, yarr, mode='mean', thresh=3, iter=5, order=3):
-    """Remove the continuum from a spectrum either by masking it or fitting and subtracting it.  
+    """Remove the continuum from a spectrum either by masking it or fitting and subtracting it.
        xarr= input x-vales (pixels or wavelength)
        yarr= flux or counts for the spectrum
        mode=None--no subtraction
@@ -110,389 +123,396 @@ def flatspectrum(xarr, yarr, mode='mean', thresh=3, iter=5, order=3):
             poly--subtact off a fit
             mask--return a spectra with continuum set to zero
     """
-    if mode=='mean':
-       #subtract off the mean value
-       sarr=yarr-clipstats(yarr, thresh, iter)[0]
-    elif mode=='poly':
-       #calculate the statistics and mask all of the mask with values above these
-       mean, std = clipstats(yarr, thresh, iter)
-       mask=(yarr<mean+thresh*std)
-       coef=np.polyfit(xarr[mask], yarr[mask], order)
-       sarr=yarr-np.polyval(coef, xarr)
-    elif mode=='mask':
-       #mask the values
-       mean, std = clipstats(yarr, thresh, iter)
-       mask=(yarr<mean+thresh*std)
-       sarr=yarr.copy()
-       sarr[mask]=0
-    else:  
-       sarr=yarr.copy()
+    if mode == 'mean':
+        # subtract off the mean value
+        sarr = yarr - clipstats(yarr, thresh, iter)[0]
+    elif mode == 'poly':
+        # calculate the statistics and mask all of the mask with values above these
+        mean, std = clipstats(yarr, thresh, iter)
+        mask = (yarr < mean + thresh * std)
+        coef = np.polyfit(xarr[mask], yarr[mask], order)
+        sarr = yarr - np.polyval(coef, xarr)
+    elif mode == 'mask':
+        # mask the values
+        mean, std = clipstats(yarr, thresh, iter)
+        mask = (yarr < mean + thresh * std)
+        sarr = yarr.copy()
+        sarr[mask] = 0
+    else:
+        sarr = yarr.copy()
     return sarr
 
-def findwavelengthsolution(xarr, farr, sl, sf, ws,  sigma=5, niter=5):
-   """Calculates the wavelength solution given a spectra and a set of lines.  Hopefully
-      an accurate first guess (ws) is provided and relative fluxes are provided as well,
-      but if not, then the program is still designed to attempt to handle it.
-  
-      returns ws
-   """
 
-   #detect lines in the input spectrum and identify the peaks and peak values
-   xp, xf=findpoints(xarr, farr, sigma, niter)
- 
-   #return no solution if no peaks were found
-   if len(xp)==0:
-      return None
+def findwavelengthsolution(xarr, farr, sl, sf, ws, sigma=5, niter=5):
+    """Calculates the wavelength solution given a spectra and a set of lines.  Hopefully
+       an accurate first guess (ws) is provided and relative fluxes are provided as well,
+       but if not, then the program is still designed to attempt to handle it.
 
-   #find the best match to the lines
-   try:
-           wp= findmatch(xarr, farr, xp, xf, sl, sf, ws)
-           for i in range(len(xp)):
-             if wp[i]>-1:
-               print xp[i],wp[i]
-   except Exception, e:
-           message = 'Unable to match line lists because %s' % e
-           raise SALTSpecError(message)
-       
+       returns ws
+    """
 
-   #if wavelength solution does not already exist, create it3dd:
-   if not isinstance(ws, WavelengthSolution.WavelengthSolution):
-           message = 'Wavelength solution does not exist'
-           raise SALTSpecError(message)
-   
-   #find the solution to the best fit
-   mask=(wp>0)
-   if mask.sum():
-       nws=WavelengthSolution.WavelengthSolution(xp[mask],wp[mask], order=ws.order, function=ws.function)
-       nws.fit()
-   else:
-       nws=None
+    # detect lines in the input spectrum and identify the peaks and peak values
+    xp, xf = findpoints(xarr, farr, sigma, niter)
 
-   return nws
+    # return no solution if no peaks were found
+    if len(xp) == 0:
+        return None
 
-def findfeatures(xarr, farr, sl, sf, ws,  sigma=5, niter=5):
-   """Given a spectra, detect lines in the spectra, and find lines in
-      the line list that correspond to those lines
-   """
-      
-   #detect lines in the input spectrum and identify the peaks and peak values
-   xp, xf=findpoints(xarr, farr, sigma, niter)
+    # find the best match to the lines
+    try:
+        wp = findmatch(xarr, farr, xp, xf, sl, sf, ws)
+        for i in range(len(xp)):
+            if wp[i] > -1:
+                print xp[i], wp[i]
+    except Exception as e:
+        message = 'Unable to match line lists because %s' % e
+        raise SALTSpecError(message)
 
-   #return no solution if no peaks were found
-   if len(xp)==0:
-      return None
+    # if wavelength solution does not already exist, create it3dd:
+    if not isinstance(ws, WavelengthSolution.WavelengthSolution):
+        message = 'Wavelength solution does not exist'
+        raise SALTSpecError(message)
 
-   #find the best match to the lines
-   try:
-           wp= findmatch(xarr, farr, xp, xf, sl, sf, ws)
-           for i in range(len(xp)):
-             if wp[i]>-1:
-               print xp[i],wp[i]
-   except Exception, e:
-           message = 'Unable to match line lists because %s' % e
-           raise SALTSpecError(message)
-   return xp, wp
+    # find the solution to the best fit
+    mask = (wp > 0)
+    if mask.sum():
+        nws = WavelengthSolution.WavelengthSolution(xp[mask], wp[mask], order=ws.order, function=ws.function)
+        nws.fit()
+    else:
+        nws = None
+
+    return nws
+
+
+def findfeatures(xarr, farr, sl, sf, ws, sigma=5, niter=5):
+    """Given a spectra, detect lines in the spectra, and find lines in
+       the line list that correspond to those lines
+    """
+
+    # detect lines in the input spectrum and identify the peaks and peak values
+    xp, xf = findpoints(xarr, farr, sigma, niter)
+
+    # return no solution if no peaks were found
+    if len(xp) == 0:
+        return None
+
+    # find the best match to the lines
+    try:
+        wp = findmatch(xarr, farr, xp, xf, sl, sf, ws)
+        for i in range(len(xp)):
+            if wp[i] > -1:
+                print xp[i], wp[i]
+    except Exception as e:
+        message = 'Unable to match line lists because %s' % e
+        raise SALTSpecError(message)
+    return xp, wp
 
 
 def findmatch(xarr, farr, xp, xf, sl, sf, ws, xlimit=5, wlimit=2):
-   """Find the best match between the observed arc lines and the spectral line list.  If available, 
-      use the line fluxes and the wavelength solution.  Returns a an array that is a wavelength 
-      for each peak wavelength
- 
-      returns wp
-   """
-   wp=xp*0.0-1
+    """Find the best match between the observed arc lines and the spectral line list.  If available,
+       use the line fluxes and the wavelength solution.  Returns a an array that is a wavelength
+       for each peak wavelength
 
-   #calculate it using only xp and sl
-   if sf==None and not ws:
-      print 'no'
+       returns wp
+    """
+    wp = xp * 0.0 - 1
 
-   #calculate it without any wavelength solution
-   elif not ws:
-      print ws
- 
-   #calculate it without any flux information
-   elif sf==None and ws:
-       for i in xf.argsort()[::-1]:
-           cx = mcentroid(xarr, farr, xc=xp[i], xdiff=4)
-           if abs(cx-xp[i]) < xlimit:
-                w=wavematch(ws.value(cx), wp, sl)
-                wp[i]=w
-                   
-   #calculate it using all of the information
-   else:
-       dcoef=ws.coef*0.0
-       dcoef[-1]=10
-       dcoef[-2]=dcoef[-2]*0.2
-       nstep=20
-       nws=spectramatch(xarr, farr, sl, sf, ws, dcoef, nstep=nstep, res=2, dres=0.1)
-       print 'nws:',nws.coef
-       for i in xf.argsort()[::-1]:
-           cx = mcentroid(xarr, farr, xc=xp[i], xdiff=4)
-           if abs(cx-xp[i]) < xlimit:
-                w=wavematch(nws.value(cx), wp, sl, wlimit=4*dcoef[-1]/nstep)
-                wp[i]=w
+    # calculate it using only xp and sl
+    if sf is None and not ws:
+        print 'no'
 
-   return wp
+    # calculate it without any wavelength solution
+    elif not ws:
+        print ws
 
-def spectramatch(xarr, farr, sw, sf,  ws, dcoef, nstep, res=2, dres=0.1):
-   """Using all the information which is available, cross correlate the observed spectra
-      and the wavelength spectra to find the best coefficients and match the data
-   """
-   #create an artificial spectrum of the lines
-   lmax=farr.max()
-   swarr, sfarr=makeartificial(sw, sf, lmax, res, dres)
+    # calculate it without any flux information
+    elif sf is None and ws:
+        for i in xf.argsort()[::-1]:
+            cx = mcentroid(xarr, farr, xc=xp[i], xdiff=4)
+            if abs(cx - xp[i]) < xlimit:
+                w = wavematch(ws.value(cx), wp, sl)
+                wp[i] = w
 
-   #Now find the best fitting coefficients for the wavelength solution
-   nws=WavelengthSolution.WavelengthSolution(ws.x_arr, ws.w_arr)
-   nws.coef=ws.coef
+    # calculate it using all of the information
+    else:
+        dcoef = ws.coef * 0.0
+        dcoef[-1] = 10
+        dcoef[-2] = dcoef[-2] * 0.2
+        nstep = 20
+        nws = spectramatch(xarr, farr, sl, sf, ws, dcoef, nstep=nstep, res=2, dres=0.1)
+        print 'nws:', nws.coef
+        for i in xf.argsort()[::-1]:
+            cx = mcentroid(xarr, farr, xc=xp[i], xdiff=4)
+            if abs(cx - xp[i]) < xlimit:
+                w = wavematch(nws.value(cx), wp, sl, wlimit=4 * dcoef[-1] / nstep)
+                wp[i] = w
 
-   #create the range of coefficents
-   dlist=mod_coef(ws.coef, dcoef, 0, nstep)
+    return wp
 
-   #loop through them and deteremine the best cofficient
-   cc_arr=np.zeros(len(dlist), dtype=float)
-   for i in range(len(dlist)):
-       #set the coeficient
-       nws.coef=dlist[i]
 
-       #set the wavelegnth coverage 
-       warr=nws.value(xarr)
+def spectramatch(xarr, farr, sw, sf, ws, dcoef, nstep, res=2, dres=0.1):
+    """Using all the information which is available, cross correlate the observed spectra
+       and the wavelength spectra to find the best coefficients and match the data
+    """
+    # create an artificial spectrum of the lines
+    lmax = farr.max()
+    swarr, sfarr = makeartificial(sw, sf, lmax, res, dres)
 
-       #resample the artificial spectrum at the same wavelengths as the 
-       asfarr=np.interp(warr, swarr, sfarr, left=0.0, right=0.0)
+    # Now find the best fitting coefficients for the wavelength solution
+    nws = WavelengthSolution.WavelengthSolution(ws.x_arr, ws.w_arr)
+    nws.coef = ws.coef
 
-       #calculate the correlation value
-       cc_arr[i]=ncor(farr, asfarr)
+    # create the range of coefficents
+    dlist = mod_coef(ws.coef, dcoef, 0, nstep)
 
-   nws.coef=dlist[cc_arr.argmax()]
+    # loop through them and deteremine the best cofficient
+    cc_arr = np.zeros(len(dlist), dtype=float)
+    for i in range(len(dlist)):
+        # set the coeficient
+        nws.coef = dlist[i]
 
-   #return the best fit solution
-   return nws
+        # set the wavelegnth coverage
+        warr = nws.value(xarr)
+
+        # resample the artificial spectrum at the same wavelengths as the
+        asfarr = np.interp(warr, swarr, sfarr, left=0.0, right=0.0)
+
+        # calculate the correlation value
+        cc_arr[i] = ncor(farr, asfarr)
+
+    nws.coef = dlist[cc_arr.argmax()]
+
+    # return the best fit solution
+    return nws
 
 
 def mod_coef(coef, dcoef, index, nstep):
-    """For a given index, return 
+    """For a given index, return
     """
-    dlist=[]
-    if index>=len(coef): return dlist
-    if dcoef[index]==0: 
-       if index<len(coef):
-          dlist.extend((mod_coef(coef, dcoef, index+1, nstep)))
-       else:
-          dlist.append(coef)
-       return dlist
-       
-    if index<len(coef)-1:
-       for x in np.arange(-dcoef[index], dcoef[index], 2*dcoef[index]/nstep):
-           ncoef=coef.copy()
-           ncoef[index] = coef[index]+x
-           dlist.extend(mod_coef(ncoef, dcoef, index+1, nstep))
+    dlist = []
+    if index >= len(coef):
+        return dlist
+    if dcoef[index] == 0:
+        if index < len(coef):
+            dlist.extend((mod_coef(coef, dcoef, index + 1, nstep)))
+        else:
+            dlist.append(coef)
+        return dlist
+
+    if index < len(coef) - 1:
+        for x in np.arange(-dcoef[index], dcoef[index], 2 * dcoef[index] / nstep):
+            ncoef = coef.copy()
+            ncoef[index] = coef[index] + x
+            dlist.extend(mod_coef(ncoef, dcoef, index + 1, nstep))
     else:
-       for x in np.arange(-dcoef[index], dcoef[index], 2*dcoef[index]/nstep):
-           ncoef=coef.copy()
-           ncoef[index] = coef[index]+x
-           dlist.append(ncoef)
+        for x in np.arange(-dcoef[index], dcoef[index], 2 * dcoef[index] / nstep):
+            ncoef = coef.copy()
+            ncoef[index] = coef[index] + x
+            dlist.append(ncoef)
     return dlist
-       
+
 
 def makeartificial(sw, sf, fmax, res, dw, pad=10, nkern=200, wrange=None):
-   """For a given line list with fluxes, create an artifical spectrum"""
-   if wrange is None:
-      wrange=[sw.min()-pad, sw.max()+pad]
-   spec=Spectrum(sw, sf, wrange=wrange, dw=dw, stype='line', sigma=res)
-   spec.flux=spec.flux*fmax/spec.flux.max()
+    """For a given line list with fluxes, create an artifical spectrum"""
+    if wrange is None:
+        wrange = [sw.min() - pad, sw.max() + pad]
+    spec = Spectrum(sw, sf, wrange=wrange, dw=dw, stype='line', sigma=res)
+    spec.flux = spec.flux * fmax / spec.flux.max()
 
-   return spec.wavelength, spec.flux
-
+    return spec.wavelength, spec.flux
 
 
 def ncor(x, y):
     """Calculate the normalized correlation of two arrays"""
-    return np.correlate(x,y, old_behavior=False)/(np.correlate(x,x, old_behavior=False)*np.correlate(y,y, old_behavior=False))**0.5
+    return np.correlate(x, y, old_behavior=False) / \
+        (np.correlate(x, x, old_behavior=False) * np.correlate(y, y, old_behavior=False)) ** 0.5
 
 
 def wavematch(w, wp, sl, wlimit=10):
-   """Compare a wavelength to an observed list and see if it matches up.  Skip 
-      if the lines is already in the wp list
-   
-   """
+    """Compare a wavelength to an observed list and see if it matches up.  Skip
+       if the lines is already in the wp list
 
-   #first remove anything already in the self.wp from the sl list
-   lines=[]
-   for x in sl:
-       if x not in wp: lines.append(x)
-   lines=np.array(lines)
+    """
 
-   #find the best match
-   dist=abs(lines-w)
-   if dist.min() < wlimit: 
-       i=dist.argmin()
-   else:
-       return -1
+    # first remove anything already in the self.wp from the sl list
+    lines = []
+    for x in sl:
+        if x not in wp:
+            lines.append(x)
+    lines = np.array(lines)
 
-   #return the values
-   return lines[i]
+    # find the best match
+    dist = abs(lines - w)
+    if dist.min() < wlimit:
+        i = dist.argmin()
+    else:
+        return -1
 
-def findfit(xp, wp,  order=3, function='poly'):
+    # return the values
+    return lines[i]
+
+
+def findfit(xp, wp, order=3, function='poly'):
     """Find the fit using just the matched points of xp and wp"""
-    ws=WavelengthSolution.WavelengthSolution(xp, wp, order=order, function=function)
+    ws = WavelengthSolution.WavelengthSolution(xp, wp, order=order, function=function)
     ws.fit()
     return ws
 
+
 def findzeropoint(xarr, farr, swarr, sfarr, ws, dc=10, nstep=20, inttype='interp'):
-   """Uses cross-correlation to find the best fitting zeropoint"""
+    """Uses cross-correlation to find the best fitting zeropoint"""
 
-   #if an initial solution, then cut the template lines to just be the length of the spectrum
-   if ws==None: return ws
+    # if an initial solution, then cut the template lines to just be the length of the spectrum
+    if ws is None:
+        return ws
 
+    # set up the the dc coefficient
+    dcoef = ws.coef * 0.0
+    dcoef[-1] = dc
 
-   #set up the the dc coefficient
-   dcoef=ws.coef*0.0
-   dcoef[-1]=dc
-
-   ws=findxcor(xarr, farr, swarr, sfarr, ws, dcoef=dcoef, nstep=nstep, inttype=inttype)
-   return ws
+    ws = findxcor(xarr, farr, swarr, sfarr, ws, dcoef=dcoef, nstep=nstep, inttype=inttype)
+    return ws
 
 
 def findxcor(xarr, farr, swarr, sfarr, ws, dcoef=None, nstep=20, inttype='interp'):
-   """Find the solution using crosscorrelation of the wavelength solution.  An initial
-      guess needs to be supplied along with the variation in each coefficient and the
-      number of steps to calculate the correlation.  The input wavelength and flux
-      for the known spectral features should be in the format where they have already
-      been convolved with the response function of the spectrograph
+    """Find the solution using crosscorrelation of the wavelength solution.  An initial
+       guess needs to be supplied along with the variation in each coefficient and the
+       number of steps to calculate the correlation.  The input wavelength and flux
+       for the known spectral features should be in the format where they have already
+       been convolved with the response function of the spectrograph
 
-      xarr--Pixel coordinates of the image
- 
-      farr--Flux values for each pixel
- 
-      swarr--Input wavelengths of known spectral features
+       xarr--Pixel coordinates of the image
 
-      sfarr--fluxes of known spectral features
+       farr--Flux values for each pixel
 
-      ws--current wavelength solution
+       swarr--Input wavelengths of known spectral features
 
-      dcoef--Variation over each coefficient for correlation
+       sfarr--fluxes of known spectral features
 
-      nstep--number of steps to sample over
+       ws--current wavelength solution
 
-      inttype--type of interpolation
-      
-   """
-   
+       dcoef--Variation over each coefficient for correlation
 
-   #cross-correlate the spectral lines and the observed fluxes in order to refine the solution
-   nws=WavelengthSolution.WavelengthSolution(ws.x_arr, ws.w_arr, order=ws.order, function=ws.function)
-   nws.setcoef(ws.coef)
+       nstep--number of steps to sample over
 
-   #create the range of coefficents
-   if dcoef==None:
-      dcoef=ws.coef*0.0+1.0    
-   dlist=mod_coef(ws.coef, dcoef, 0, nstep)
+       inttype--type of interpolation
 
-   #loop through them and deteremine the best cofficient
-   cc_arr=np.zeros(len(dlist), dtype=float)
-   zp_arr=np.zeros(len(dlist), dtype=float)
-   dp_arr=np.zeros(len(dlist), dtype=float)
-   for i in range(len(dlist)):
-       #set the coeficient
-       nws.setcoef(dlist[i])
+    """
 
-       #set the wavelegnth coverage 
-       warr=nws.value(xarr)
+    # cross-correlate the spectral lines and the observed fluxes in order to refine the solution
+    nws = WavelengthSolution.WavelengthSolution(ws.x_arr, ws.w_arr, order=ws.order, function=ws.function)
+    nws.setcoef(ws.coef)
 
-       #resample the artificial spectrum at the same wavelengths as the 
-       asfarr=interpolate(warr, swarr, sfarr, type=inttype, left=0.0, right=0.0)
+    # create the range of coefficents
+    if dcoef is None:
+        dcoef = ws.coef * 0.0 + 1.0
+    dlist = mod_coef(ws.coef, dcoef, 0, nstep)
 
-       #calculate the correlation value
-       cc_arr[i]=ncor(farr, asfarr)
+    # loop through them and deteremine the best cofficient
+    cc_arr = np.zeros(len(dlist), dtype=float)
+    zp_arr = np.zeros(len(dlist), dtype=float)
+    dp_arr = np.zeros(len(dlist), dtype=float)
+    for i in range(len(dlist)):
+        # set the coeficient
+        nws.setcoef(dlist[i])
 
-   #now set the best coefficients
-   i=cc_arr.argmax()
-   bcoef=dlist[i]
-   nws.setcoef(bcoef)
-   darr=np.array(dlist)
-   for j in range(len(nws.coef)):
-       if dcoef[j]!=0.0:
-          tk=np.polyfit(darr[:,j], cc_arr, 2)
-          bval=-0.5*tk[1]/tk[0]
-          if abs(bval-bcoef[j])<dcoef[j]:
-             bcoef[j]=bval
-         
-          #coef=np.polyfit(dlist[:][j], cc_arr, 2)
-          #nws.coef[j]=-0.5*coef[1]/coef[0]
+        # set the wavelegnth coverage
+        warr = nws.value(xarr)
 
-   return nws
+        # resample the artificial spectrum at the same wavelengths as the
+        asfarr = interpolate(warr, swarr, sfarr, type=inttype, left=0.0, right=0.0)
+
+        # calculate the correlation value
+        cc_arr[i] = ncor(farr, asfarr)
+
+    # now set the best coefficients
+    i = cc_arr.argmax()
+    bcoef = dlist[i]
+    nws.setcoef(bcoef)
+    darr = np.array(dlist)
+    for j in range(len(nws.coef)):
+        if dcoef[j] != 0.0:
+            tk = np.polyfit(darr[:, j], cc_arr, 2)
+            bval = -0.5 * tk[1] / tk[0]
+            if abs(bval - bcoef[j]) < dcoef[j]:
+                bcoef[j] = bval
+
+            #coef=np.polyfit(dlist[:][j], cc_arr, 2)
+            # nws.coef[j]=-0.5*coef[1]/coef[0]
+
+    return nws
 
 #------------------------------------------------------------------
 # Read in the line list file
+
 
 def readlinelist(linelist):
-   """Read in the line lists.  Determine what type of file it is.  The default is
-       an ascii file with line and relative intensity.  The other types are just line, 
-       or a wavelenght calibrated fits file 
+    """Read in the line lists.  Determine what type of file it is.  The default is
+        an ascii file with line and relative intensity.  The other types are just line,
+        or a wavelenght calibrated fits file
 
-      return lines, fluxes, and status
-   """
-   slines=[]
-   sfluxes=[]
-   status=0
+       return lines, fluxes, and status
+    """
+    slines = []
+    sfluxes = []
+    status = 0
 
-   #Check to see if it is a fits file
-   #if not, then read in the ascii file
-   if linelist[-4:]=='fits':
-       try:
-           slines, sfluxes=readfitslinelist(linelist)
-       except Exception, e:
-           message='Unable to read in the line list %s because %s' % (linelist, e)
-           raise SALTSpecError(message)
-   else:
-       try:
-           slines, sfluxes=readasciilinelist(linelist)
-       except Exception, e:
-           message='Unable to read in the line list %s because %s' % (linelist, e)
-           raise SALTSpecError(message)
+    # Check to see if it is a fits file
+    # if not, then read in the ascii file
+    if linelist[-4:] == 'fits':
+        try:
+            slines, sfluxes = readfitslinelist(linelist)
+        except Exception as e:
+            message = 'Unable to read in the line list %s because %s' % (linelist, e)
+            raise SALTSpecError(message)
+    else:
+        try:
+            slines, sfluxes = readasciilinelist(linelist)
+        except Exception as e:
+            message = 'Unable to read in the line list %s because %s' % (linelist, e)
+            raise SALTSpecError(message)
 
-   #conver to numpy arrays   
-   try:
-       slines=np.asarray(slines)
-       sfluxes=np.asarray(sfluxes)
-   except Exception, e:
-       message='Unable to create numpy arrays because %s' % (e)
-       raise SALTSpecError(logfile, message)
+    # conver to numpy arrays
+    try:
+        slines = np.asarray(slines)
+        sfluxes = np.asarray(sfluxes)
+    except Exception as e:
+        message = 'Unable to create numpy arrays because %s' % (e)
+        raise SALTSpecError(logfile, message)
 
-   return slines, sfluxes
+    return slines, sfluxes
 
 #------------------------------------------------------------------
 # Read in the line list file
 
+
 def readfitslinelist(linelist):
-   """Read in the line lists from an fits file.  If it is a 2-D array
-      it will assume that it is an image and select the central wavlength
+    """Read in the line lists from an fits file.  If it is a 2-D array
+       it will assume that it is an image and select the central wavlength
 
-      return lines, fluxes, and status
-   """
-   slines=[]
-   sfluxes=[]
-   
-   #open the image
-   shdu=pyfits.open(linelist)
-   nhdu=len(shdu)
-   #determine if it is a one or two-d image
-   #if ndhu=0 then assume that it is in the zeroth image
-   #otherwise assume the data is in the first extension
-   #assumes the x-axis is the wavelength axis
-   if nhdu==1:
-      ctype1=shdu[0].header['CTYPE1']
-      crval1=shdu[0].header['CRVAL1']
-      cdelt1=shdu[0].header['CDELT1']
-      if shdu[0].data.ndim==1:
-           data=shdu[0].data
-           wave=crval1+cdelt1*np.arange(len(shdu[0].data))
+       return lines, fluxes, and status
+    """
+    slines = []
+    sfluxes = []
 
-   #detect lines in the input spectrum and identify the peaks and peak values
-   slines, sfluxes=findpoints(wave, data, 3, 5)
-   """
+    # open the image
+    shdu = pyfits.open(linelist)
+    nhdu = len(shdu)
+    # determine if it is a one or two-d image
+    # if ndhu=0 then assume that it is in the zeroth image
+    # otherwise assume the data is in the first extension
+    # assumes the x-axis is the wavelength axis
+    if nhdu == 1:
+        ctype1 = shdu[0].header['CTYPE1']
+        crval1 = shdu[0].header['CRVAL1']
+        cdelt1 = shdu[0].header['CDELT1']
+        if shdu[0].data.ndim == 1:
+            data = shdu[0].data
+            wave = crval1 + cdelt1 * np.arange(len(shdu[0].data))
+
+    # detect lines in the input spectrum and identify the peaks and peak values
+    slines, sfluxes = findpoints(wave, data, 3, 5)
+    """
    figure(figsize=(8,8), dpi=72)
    axes([0.1, 0.1, 0.8, 0.8])
    plot(wave, data, ls='-')
@@ -501,36 +521,35 @@ def readfitslinelist(linelist):
    show()
    """
 
-   return slines, sfluxes
+    return slines, sfluxes
 
 #------------------------------------------------------------------
 # Read in the line list file
 
+
 def readasciilinelist(linelist):
-   """Read in the line lists from an ascii file.  It can either be a 
-       file with one or two columns.  Only read in lines that are not 
-       commented out.
+    """Read in the line lists from an ascii file.  It can either be a
+        file with one or two columns.  Only read in lines that are not
+        commented out.
 
-      return lines, fluxes, and status
-   """
-   slines=[]
-   sfluxes=[]
+       return lines, fluxes, and status
+    """
+    slines = []
+    sfluxes = []
 
-   #read in the file
-   f=open(linelist)
-   lines=f.readlines()
-   f.close()
+    # read in the file
+    f = open(linelist)
+    lines = f.readlines()
+    f.close()
 
-   #for each line, 
-   for l in lines:
-        l=l.strip()
+    # for each line,
+    for l in lines:
+        l = l.strip()
         if not (l and l.startswith('#')):
-           l=l.split()
-           slines.append(float(l[0]))
-           try:
-              sfluxes.append(float(l[1]))
-           except IndexError:
-              sfluxes.append(-1)
-   return slines, sfluxes
-
-
+            l = l.split()
+            slines.append(float(l[0]))
+            try:
+                sfluxes.append(float(l[1]))
+            except IndexError:
+                sfluxes.append(-1)
+    return slines, sfluxes

--- a/PySpectrograph/Models/RSSModel.py
+++ b/PySpectrograph/Models/RSSModel.py
@@ -1,16 +1,16 @@
-"""RSSmodel is a class that describes the optical arm of the Robert Stobie     
-Spectrograph.  This model inherents from Spectragraph.  The RSS is currently 
+"""RSSmodel is a class that describes the optical arm of the Robert Stobie
+Spectrograph.  This model inherents from Spectragraph.  The RSS is currently
 described by the grating, grating angle, and camera angle.  All other components
-are fixed.  
+are fixed.
 
 20090913  SMC   First version
-20120325  SMC   -Update to include deviations in the as built spectrograph in the grating angle 
+20120325  SMC   -Update to include deviations in the as built spectrograph in the grating angle
                 -include the most up to date chip geometry
 20120511  SMC   -Updated to inherit directly from Spectrograph
                 -Included get_wavelength
 
 Limitations:
--Set the geometry of the CCDs using the current geometry file instead of the 
+-Set the geometry of the CCDs using the current geometry file instead of the
  default given here
 
 """
@@ -19,132 +19,131 @@ import numpy as np
 
 from PySpectrograph.Spectrograph import Spectrograph, Grating, Optics, CCD, Detector, Slit
 
-class RSSError(Exception): 
+
+class RSSError(Exception):
     pass
 
+
 class RSSModel (Spectrograph):
-   """A model describing the RSS spectrograph"""
 
-   def __init__(self, grating_name='None', gratang=45, camang=45, slit=1.0,  \
-                      xbin=2, ybin=2, xpos=-0.2666, ypos=0.0117, wavelength=None):
-       
-       #set up the parts of the grating
-       self.grating_name=grating_name
-       self.slitang=slit
+    """A model describing the RSS spectrograph"""
 
+    def __init__(self, grating_name='None', gratang=45, camang=45, slit=1.0,
+                 xbin=2, ybin=2, xpos=-0.2666, ypos=0.0117, wavelength=None):
 
-       #set the telescope
-       self.set_telescope('RSS')
+        # set up the parts of the grating
+        self.grating_name = grating_name
+        self.slitang = slit
 
-       #set the collimator
-       self.set_collimator('RSS')
+        # set the telescope
+        self.set_telescope('RSS')
 
-       #set the camera
-       self.set_camera('RSS', wavelength=wavelength)
+        # set the collimator
+        self.set_collimator('RSS')
 
-       #set the detector
-       self.set_detector('RSS', xbin=xbin, ybin=ybin, xpos=xpos, ypos=ypos)
+        # set the camera
+        self.set_camera('RSS', wavelength=wavelength)
 
-       #set up the grating
-       self.set_grating(self.grating_name)
- 
-       #set up the slit
-       self.set_slit(self.slitang)
+        # set the detector
+        self.set_detector('RSS', xbin=xbin, ybin=ybin, xpos=xpos, ypos=ypos)
 
-       #set up the grating angle
-       self.gratang=gratang
-       self.camang=camang
+        # set up the grating
+        self.set_grating(self.grating_name)
 
-   def alpha(self, da=0.23):
-       """Return the value of alpha for the spectrograph"""
-       return self.gratang+da
+        # set up the slit
+        self.set_slit(self.slitang)
 
-   def beta(self, mF=4.2e-5, db=0.00):
-       """Return the value of beta for the spectrograph
-          
-          Beta_o=(1+fA)*(camang)-gratang+beta_o
-       """
-       return (1+mF)*self.camang-self.alpha()+db
+        # set up the grating angle
+        self.gratang = gratang
+        self.camang = camang
 
-   def focallength(self, focallength=328.0, wavelength=None):
-       """The camera focal lenght set oaccording to the following 
-          Wavelength should be provided in angstroms
+    def alpha(self, da=0.23):
+        """Return the value of alpha for the spectrograph"""
+        return self.gratang + da
 
-       """
-       if wavelength is None:  return focallength
-       
-       L=(wavelength-4000.0)/1000.0
-       return 327.66+-0.1861*L+0.5061*L**2+-0.2100*L**3+0.0365*L**4+-0.0023*L**5
+    def beta(self, mF=4.2e-5, db=0.00):
+        """Return the value of beta for the spectrograph
 
-   def get_wavelength(self, xarr, gamma=0.0):
-       """For a given spectrograph configuration, return the wavelength coordinate
-          associated with a pixel coordinate.   
+           Beta_o=(1+fA)*(camang)-gratang+beta_o
+        """
+        return (1 + mF) * self.camang - self.alpha() + db
 
-          xarr: 1-D Array of pixel coordinates
-          gamma: Value of gamma for the row being analyzed
+    def focallength(self, focallength=328.0, wavelength=None):
+        """The camera focal lenght set oaccording to the following
+           Wavelength should be provided in angstroms
 
-          returns an array of wavelengths in mm
-       """
-       d=self.detector.xbin*self.detector.pix_size*(xarr-self.detector.get_xpixcenter())
-       dbeta=-np.degrees(np.arctan(d/self.camera.focallength))
-       return self.calc_wavelength(self.alpha(), -self.beta()+dbeta, gamma=gamma)
-      
+        """
+        if wavelength is None:
+            return focallength
 
+        L = (wavelength - 4000.0) / 1000.0
+        return 327.66 + -0.1861 * L + 0.5061 * L ** 2 + -0.2100 * L ** 3 + 0.0365 * L ** 4 + -0.0023 * L ** 5
 
-   def set_telescope(self, name='RSS'):
-       if name=='RSS':
-           self.telescope=Optics(name=name, focallength=46200.0)
-       elif name=='SALT':
-           self.telescope=Optics(name=name, focallength=46200.0)
-       else:
-           raise RSSError('%s is not a supported Telescope' % name)
+    def get_wavelength(self, xarr, gamma=0.0):
+        """For a given spectrograph configuration, return the wavelength coordinate
+           associated with a pixel coordinate.
 
-   def set_collimator(self, name='RSS', focallength=630.0):
-       if name=='RSS':
-           self.collimator=Optics(name=name, focallength=focallength)
-       else:
-           raise RSSError('%s is not a supported collimator' % name)
+           xarr: 1-D Array of pixel coordinates
+           gamma: Value of gamma for the row being analyzed
 
-   def set_camera(self, name='RSS', wavelength=None):
-       if name=='RSS':
-           self.camera=Optics(name=name, focallength=self.focallength())
-       else:
-           raise RSSError('%s is not a supported camera' % name)
+           returns an array of wavelengths in mm
+        """
+        d = self.detector.xbin * self.detector.pix_size * (xarr - self.detector.get_xpixcenter())
+        dbeta = -np.degrees(np.arctan(d / self.camera.focallength))
+        return self.calc_wavelength(self.alpha(), -self.beta() + dbeta, gamma=gamma)
 
+    def set_telescope(self, name='RSS'):
+        if name == 'RSS':
+            self.telescope = Optics(name=name, focallength=46200.0)
+        elif name == 'SALT':
+            self.telescope = Optics(name=name, focallength=46200.0)
+        else:
+            raise RSSError('%s is not a supported Telescope' % name)
 
-   def set_detector(self, name='RSS', geom=None, xbin=2, ybin=2, xpos=0, ypos=0):
-       if name=='RSS':
-           if geom:
-               pass
-           else:
-               #version 1
-               #ccd1=Spectrograph.CCD(name='CCD1',  xpix=2032, ypix=4102, pix_size=0.015, xpos=-32.19, ypos=0)
-               #updated on 20120325 
-               ccd1=CCD(name='CCD1',  xpix=2032, ypix=4102, pix_size=0.015, xpos=-32.40, ypos=0.0486)
-               ccd2=CCD(name='CCD1',  xpix=2032, ypix=4102, pix_size=0.015, xpos=0,      ypos=0)
-               ccd3=CCD(name='CCD1',  xpix=2032, ypix=4102, pix_size=0.015, xpos= 32.218, ypos=0.0196)
-           self.detector=Detector(name=name, ccd=[ccd1, ccd2, ccd3], xbin=xbin, ybin=ybin, \
-                                      xpos=xpos, ypos=ypos, plate_scale=0.224)
-       else:
-           raise RSSError('%s is not a supported detector' % name)
+    def set_collimator(self, name='RSS', focallength=630.0):
+        if name == 'RSS':
+            self.collimator = Optics(name=name, focallength=focallength)
+        else:
+            raise RSSError('%s is not a supported collimator' % name)
 
-   def set_grating(self, name=None):
-       if name=='PG0300':
-          self.grating=Grating(name='PG0300', spacing=300)
-       elif name=='PG0900':
-          self.grating=Grating(name='PG0900', spacing=903.20)
-       elif name=='PG1300':
-          self.grating=Grating(name='PG1300', spacing=1301.20)
-       elif name=='PG1800':
-          self.grating=Grating(name='PG1800', spacing=1801.65)
-       elif name=='PG2300':
-          self.grating=Grating(name='PG2300', spacing=2302.15)
-       elif name=='PG3000':
-          self.grating=Grating(name='PG3000', spacing=2999.98)
-       else:
-          raise RSSError('%s is not a supported RSS grating' % name)
-      
+    def set_camera(self, name='RSS', wavelength=None):
+        if name == 'RSS':
+            self.camera = Optics(name=name, focallength=self.focallength())
+        else:
+            raise RSSError('%s is not a supported camera' % name)
 
-   def set_slit(self, slitang=1.0):
-       self.slit=Slit(name='LongSlit', phi=slitang)
-       self.slit.width=self.slit.calc_width(self.telescope.focallength)
+    def set_detector(self, name='RSS', geom=None, xbin=2, ybin=2, xpos=0, ypos=0):
+        if name == 'RSS':
+            if geom:
+                pass
+            else:
+                # version 1
+                #ccd1=Spectrograph.CCD(name='CCD1',  xpix=2032, ypix=4102, pix_size=0.015, xpos=-32.19, ypos=0)
+                # updated on 20120325
+                ccd1 = CCD(name='CCD1', xpix=2032, ypix=4102, pix_size=0.015, xpos=-32.40, ypos=0.0486)
+                ccd2 = CCD(name='CCD1', xpix=2032, ypix=4102, pix_size=0.015, xpos=0, ypos=0)
+                ccd3 = CCD(name='CCD1', xpix=2032, ypix=4102, pix_size=0.015, xpos=32.218, ypos=0.0196)
+            self.detector = Detector(name=name, ccd=[ccd1, ccd2, ccd3], xbin=xbin, ybin=ybin,
+                                     xpos=xpos, ypos=ypos, plate_scale=0.224)
+        else:
+            raise RSSError('%s is not a supported detector' % name)
+
+    def set_grating(self, name=None):
+        if name == 'PG0300':
+            self.grating = Grating(name='PG0300', spacing=300)
+        elif name == 'PG0900':
+            self.grating = Grating(name='PG0900', spacing=903.20)
+        elif name == 'PG1300':
+            self.grating = Grating(name='PG1300', spacing=1301.20)
+        elif name == 'PG1800':
+            self.grating = Grating(name='PG1800', spacing=1801.65)
+        elif name == 'PG2300':
+            self.grating = Grating(name='PG2300', spacing=2302.15)
+        elif name == 'PG3000':
+            self.grating = Grating(name='PG3000', spacing=2999.98)
+        else:
+            raise RSSError('%s is not a supported RSS grating' % name)
+
+    def set_slit(self, slitang=1.0):
+        self.slit = Slit(name='LongSlit', phi=slitang)
+        self.slit.width = self.slit.calc_width(self.telescope.focallength)

--- a/PySpectrograph/Models/__init__.py
+++ b/PySpectrograph/Models/__init__.py
@@ -1,8 +1,6 @@
-"""Models contains different models for spectrographs.  These current 
+"""Models contains different models for spectrographs.  These current
 include the following spectrographs:
 
 RSSModel--RSS Spectrograph on SALT
 
 """
-
-

--- a/PySpectrograph/Spectra/Spectrum.py
+++ b/PySpectrograph/Spectra/Spectrum.py
@@ -10,160 +10,157 @@ Limitations:
 import numpy as np
 from PySpectrograph.Utilities.Functions import Normal
 
+
 class SpectrumError(Exception):
-   """Exception Raised for Spectrograph errors"""
-   pass
 
-
+    """Exception Raised for Spectrograph errors"""
+    pass
 
 
 class Spectrum:
-   """Spectrum is a class for handling and creating spectra.  It can either 
-      be created from a line list or a continuum flux.  If no inputs are given,
-      it creates an empty object that has a wavelength range from 3000-9000 and 
-      a sampling of 0.1.  
 
-      Parameters
-      ----------
-      wavelength:  An array of wavelengths for values in flux
+    """Spectrum is a class for handling and creating spectra.  It can either
+       be created from a line list or a continuum flux.  If no inputs are given,
+       it creates an empty object that has a wavelength range from 3000-9000 and
+       a sampling of 0.1.
 
-      flux:  An array of fluxes.  It can either be lines or continuum
+       Parameters
+       ----------
+       wavelength:  An array of wavelengths for values in flux
 
-      wrange:  wavelenght range of flux
-   
-      dw: sampling of the spectrum
-     
-      stype: line--the input spectrum is a list of lines
-             continuum--the input spectrum is continuum values
+       flux:  An array of fluxes.  It can either be lines or continuum
 
-      wavelength_units:  Units of the wavelength array
+       wrange:  wavelenght range of flux
 
-      flux_units:  Units of the wavelength array
-   """
- 
-   def __init__(self, wavelength=None, flux=None, var=None, wrange=None, dw=0.1, \
-                sigma=1e-1, stype='line', wavelength_units=None, flux_units=None):
+       dw: sampling of the spectrum
 
-       if wavelength is None and wrange is None:
-           raise SpectrumError('Please specify either wavelength or wrange')
+       stype: line--the input spectrum is a list of lines
+              continuum--the input spectrum is continuum values
 
-       
+       wavelength_units:  Units of the wavelength array
 
-       #set the variables
-       self.wrange=wrange
-       self.dw=dw
-       self.wavelength_units=wavelength_units
-       self.stype=stype
-       self.flux_units=flux_units
-       self.sigma=sigma
-       self.var=var
+       flux_units:  Units of the wavelength array
+    """
 
-       #set the wavelength
-       self.set_wavelength(wavelength)
+    def __init__(self, wavelength=None, flux=None, var=None, wrange=None, dw=0.1,
+                 sigma=1e-1, stype='line', wavelength_units=None, flux_units=None):
 
-       #set the flux
-       self.set_flux(wavelength, flux)
-          
-       return
+        if wavelength is None and wrange is None:
+            raise SpectrumError('Please specify either wavelength or wrange')
 
+        # set the variables
+        self.wrange = wrange
+        self.dw = dw
+        self.wavelength_units = wavelength_units
+        self.stype = stype
+        self.flux_units = flux_units
+        self.sigma = sigma
+        self.var = var
 
-   def set_wavelength(self, wavelength, new=False):
-       """Set the wavelength scale 
+        # set the wavelength
+        self.set_wavelength(wavelength)
 
-          If new is True, then it will create a new wavelength
-          using wrange and dw
+        # set the flux
+        self.set_flux(wavelength, flux)
 
-       """
+        return
 
-       if self.wrange is None and wavelength is not None:
-           self.wrange=[wavelength.min(), wavelength.max()]
+    def set_wavelength(self, wavelength, new=False):
+        """Set the wavelength scale
 
-       if self.stype=='line' or new:
-           self.wavelength=np.arange(self.wrange[0], self.wrange[1], self.dw)
-       elif self.stype=='continuum':
-           self.wavelength=wavelength
-       else:
-           self.wavelength=wavelength
+           If new is True, then it will create a new wavelength
+           using wrange and dw
 
-       self.nwave=len(self.wavelength)
+        """
 
+        if self.wrange is None and wavelength is not None:
+            self.wrange = [wavelength.min(), wavelength.max()]
 
-   def set_flux(self, wavelength, flux):
-       """Set the flux levels"""
-        
-       if flux is not None and len(flux)==self.nwave:
-           self.flux=flux
+        if self.stype == 'line' or new:
+            self.wavelength = np.arange(self.wrange[0], self.wrange[1], self.dw)
+        elif self.stype == 'continuum':
+            self.wavelength = wavelength
+        else:
+            self.wavelength = wavelength
 
-       elif flux is not None and wavelength is not None:
-           if self.stype=='line':
-               self.flux=np.zeros(self.nwave, dtype=float)
-               for w,f in zip(wavelength, flux):
-                      self.flux += Normal(self.wavelength, w, self.sigma*self.dw, f)
-           elif self.stype=='continuum':
-               self.flux=np.interp(self.wavelength, wavelength, flux)
-           else:
-               raise SpectrumError('%s is not an acceptable stype option' % stype)
-       else:
-           self.flux=np.zeros(self.nwave,dtype=float) 
+        self.nwave = len(self.wavelength)
 
-   def set_dispersion(self, sigma=1.0, nkern=20, ktype='Gaussian', func=None):
-       """Applies an dispersion to the spectrum.  
+    def set_flux(self, wavelength, flux):
+        """Set the flux levels"""
 
-          sigma:  Dispersion to apply if assuming a Gaussian in units of wavelength
+        if flux is not None and len(flux) == self.nwave:
+            self.flux = flux
 
-          nkern:  sampling of kernal
- 
-          ktype:  'Gaussian'--Apply a Gaussian function
-                  'User'  -- Use a user supplied kernal
-          
-          func:   User supplied kernal
+        elif flux is not None and wavelength is not None:
+            if self.stype == 'line':
+                self.flux = np.zeros(self.nwave, dtype=float)
+                for w, f in zip(wavelength, flux):
+                    self.flux += Normal(self.wavelength, w, self.sigma * self.dw, f)
+            elif self.stype == 'continuum':
+                self.flux = np.interp(self.wavelength, wavelength, flux)
+            else:
+                raise SpectrumError('%s is not an acceptable stype option' % stype)
+        else:
+            self.flux = np.zeros(self.nwave, dtype=float)
 
-       """
-       if ktype=='Gaussian':
-           xkern=np.arange(nkern)
-           kern=np.exp(-(xkern-0.5*nkern)**2/(sigma/self.dw)**2)
-       elif ktype=='User':
-           kern=func
-       else:
-           raise SpectrumError('%s is not an acceptable kernal option' % ktype)
+    def set_dispersion(self, sigma=1.0, nkern=20, ktype='Gaussian', func=None):
+        """Applies an dispersion to the spectrum.
 
+           sigma:  Dispersion to apply if assuming a Gaussian in units of wavelength
 
-       return np.convolve(self.flux, kern, mode='same')
+           nkern:  sampling of kernal
 
-   def get_flux(self, w):
-       """Given a wavelength w, return what the flux value is"""
-       return np.interp(w, self.wavelength, self.flux)
+           ktype:  'Gaussian'--Apply a Gaussian function
+                   'User'  -- Use a user supplied kernal
 
-   def interp(self, warr):
-       """Re-interpolate the spectrum such that the wavelength sampling is given by warr"""
-       self.flux=np.interp(warr, self.wavelength, self.flux)
-       self.wavelength=warr
+           func:   User supplied kernal
+
+        """
+        if ktype == 'Gaussian':
+            xkern = np.arange(nkern)
+            kern = np.exp(-(xkern - 0.5 * nkern) ** 2 / (sigma / self.dw) ** 2)
+        elif ktype == 'User':
+            kern = func
+        else:
+            raise SpectrumError('%s is not an acceptable kernal option' % ktype)
+
+        return np.convolve(self.flux, kern, mode='same')
+
+    def get_flux(self, w):
+        """Given a wavelength w, return what the flux value is"""
+        return np.interp(w, self.wavelength, self.flux)
+
+    def interp(self, warr):
+        """Re-interpolate the spectrum such that the wavelength sampling is given by warr"""
+        self.flux = np.interp(warr, self.wavelength, self.flux)
+        self.wavelength = warr
 
 """
 TODO:
-Here's the full text from Morton 1991 ApJS 77, 119 and it is a 
-good question whether we should adopt the data from Peck and 
+Here's the full text from Morton 1991 ApJS 77, 119 and it is a
+good question whether we should adopt the data from Peck and
 Reeder as IR data will be important for us.
 
 The IAU standard for conversion between air and vacuum wavelengths is,
-according to Oosterhoff (1957) and Edlen (1953), 
+according to Oosterhoff (1957) and Edlen (1953),
 
 \begin{equation}
 \frac{\lambda_{vac}-\lambda_{air}}{\lambda_{air}}=(n-1) =
    6.4328\times10^{-5}+ \frac{2.94981 times10^{-2}}{146-\sigma^2}
    +\frac{2.5540\times10^{-4}}{41-\sigma^2}
 \end{equation}
-where $\sigma=10^4/$, wiht $\lambda$ in angstroms.  Edlen (1966) and Peck 
+where $\sigma=10^4/$, wiht $\lambda$ in angstroms.  Edlen (1966) and Peck
 & Reeder (1972) have proposed improvmeents that primarily affect infrared
 wavelengths, but equation (3) was used here.
 
-More recently, this has been updated in IDLASTRO with a 
+More recently, this has been updated in IDLASTRO with a
 formula from Ciddor 1996, Applied Optics 62, 958
 See http://idlastro.gsfc.nasa.gov/ftp/pro/astro/airtovac.pro
 """
 
+
 def air2vac(w_air, mode='Morton'):
-    """Given an wavelength in units of 
+    """Given an wavelength in units of
 
     w--wavelength in air in units of angstrom
 
@@ -172,19 +169,20 @@ def air2vac(w_air, mode='Morton'):
        Ciddor--Ciddor 1996, Applied Optics 62, 958
 
     """
-    if mode=='Morton':
-        sigmasq=(1e4/w_air)**2
-        w_vac=w_air*(1+6.4328e-5+2.94981e-2/(146.0-sigmasq)+2.5540e-4/(41.0-sigmasq))
-    elif mode=='Ciddor':
-        sigmasq=(1e4/w_air)**2
-        w_vac=w_air*(1+5.792105e-2/(238.0185-sigmasq)+1.67917e-3/(57.362-sigmasq))
+    if mode == 'Morton':
+        sigmasq = (1e4 / w_air) ** 2
+        w_vac = w_air * (1 + 6.4328e-5 + 2.94981e-2 / (146.0 - sigmasq) + 2.5540e-4 / (41.0 - sigmasq))
+    elif mode == 'Ciddor':
+        sigmasq = (1e4 / w_air) ** 2
+        w_vac = w_air * (1 + 5.792105e-2 / (238.0185 - sigmasq) + 1.67917e-3 / (57.362 - sigmasq))
     else:
         raise SpectrumError('%s is an invalid mode' % mode)
 
     return w_vac
 
+
 def vac2air(w_vac, mode='Morton'):
-    """Given an wavelength in units of 
+    """Given an wavelength in units of
 
     w--wavelength in air in units of angstrom
 
@@ -193,53 +191,55 @@ def vac2air(w_vac, mode='Morton'):
        Ciddor--Ciddor 1996, Applied Optics 62, 958
 
     """
-    if mode=='Morton':
-        sigmasq=(1e4/w_vac)**2
-        w_air=w_vac/(1+6.4328e-5+2.94981e-2/(146.0-sigmasq)+2.5540e-4/(41.0-sigmasq))
-    elif mode=='Ciddor':
-        sigmasq=(1e4/w_vac)**2
-        w_air=w_vac/(1+5.792105e-2/(238.0185-sigmasq)+1.67917e-3/(57.362-sigmasq))
+    if mode == 'Morton':
+        sigmasq = (1e4 / w_vac) ** 2
+        w_air = w_vac / (1 + 6.4328e-5 + 2.94981e-2 / (146.0 - sigmasq) + 2.5540e-4 / (41.0 - sigmasq))
+    elif mode == 'Ciddor':
+        sigmasq = (1e4 / w_vac) ** 2
+        w_air = w_vac / (1 + 5.792105e-2 / (238.0185 - sigmasq) + 1.67917e-3 / (57.362 - sigmasq))
     else:
         raise SpectrumError('%s is an invalid mode' % mode)
 
     return w_air
 
+
 def fnutofwave(warr, farr):
     """Converts farr in ergs/s/cm2/Hz to ergs/s/cm2/A"""
-    c= 2.99792458e18 #spped of light in Angstroms/s
-    return  farr*c/warr**2
+    c = 2.99792458e18  # spped of light in Angstroms/s
+    return farr * c / warr ** 2
 
 
 def magtoflux(marr, fzero):
-   """Convert from magnitude to flux.
-    marr--input array in mags
-    fzero--zero point for the conversion
-   """
-   return fzero*10**(-0.4*marr)
+    """Convert from magnitude to flux.
+     marr--input array in mags
+     fzero--zero point for the conversion
+    """
+    return fzero * 10 ** (-0.4 * marr)
+
 
 def fluxtomag(farr, fzero):
-   """"Convert from flux to magnitudes
-       farr--input array in flux units
-       fzero--zero point for the converion
-   """
-   return -2.5*np.log10(farr/fzero)
-        
+    """"Convert from flux to magnitudes
+        farr--input array in flux units
+        fzero--zero point for the converion
+    """
+    return -2.5 * np.log10(farr / fzero)
 
-if __name__=='__main__':
-   import sys
-   from pylab import *
 
-   infile=sys.argv[1]
-   stype=sys.argv[2]
-   w1=float(sys.argv[3])
-   w2=float(sys.argv[4])
-   dw=float(sys.argv[5])
+if __name__ == '__main__':
+    import sys
+    from pylab import *
 
-   w,s=np.loadtxt(infile, usecols=(0,1),unpack=True)
+    infile = sys.argv[1]
+    stype = sys.argv[2]
+    w1 = float(sys.argv[3])
+    w2 = float(sys.argv[4])
+    dw = float(sys.argv[5])
 
-   spec=Spectrum(w, s, wrange=[w1, w2], dw=dw, stype=stype)
-   spec.set_dispersion(2, nkern=200)
+    w, s = np.loadtxt(infile, usecols=(0, 1), unpack=True)
 
-   figure()
-   plot(spec.wavelength, spec.flux)
-   show()
+    spec = Spectrum(w, s, wrange=[w1, w2], dw=dw, stype=stype)
+    spec.set_dispersion(2, nkern=200)
+
+    figure()
+    plot(spec.wavelength, spec.flux)
+    show()

--- a/PySpectrograph/Spectra/__init__.py
+++ b/PySpectrograph/Spectra/__init__.py
@@ -1,8 +1,7 @@
-"""Spectra includes models for a spectrum 
+"""Spectra includes models for a spectrum
 
 
 """
 
-import Spectrum
+from . import Spectrum
 #from Spectrum import Spectrum
-

--- a/PySpectrograph/Spectra/apext.py
+++ b/PySpectrograph/Spectra/apext.py
@@ -1,46 +1,49 @@
 #
-#APEXT--Extract a 1-D spectra from a 2-D image
+# APEXT--Extract a 1-D spectra from a 2-D image
 #
 #
 #
 import math
-import numpy as np 
+import numpy as np
+
 
 def makeflat(arr, y1, y2):
-   """For a 2-D array, compress it along the y-dimension to make a one dimensional
-      array
-   """ 
-   y1=max(0,y1)
-   y2=min(len(arr), y2)
-   #return the 1-D array if only a single line is requested
-   if abs(y1-y2)<=1:  return arr[y1,:]
+    """For a 2-D array, compress it along the y-dimension to make a one dimensional
+       array
+    """
+    y1 = max(0, y1)
+    y2 = min(len(arr), y2)
+    # return the 1-D array if only a single line is requested
+    if abs(y1 - y2) <= 1:
+        return arr[y1, :]
 
-   #sum up the array along for the full value
-   return arr[y1:y2,:].sum(axis=0)
-   
+    # sum up the array along for the full value
+    return arr[y1:y2, :].sum(axis=0)
+
 
 class apext:
-   """A class for extracting a 1-D spectra from a 2-D image"""
-   def __init__(self, wave, data, ivar=None):
-       self.data=data
-       self.wave=wave
-       self.nwave=len(wave)
-       if ivar==None:
-          self.ivar=None
-       else: 
-          self.ivar=ivar
 
-   def flatten(self, y1, y2):
-       """Compress the 2-D array down to 1-D. This is just either done by 
-          a straight summation or by a weighted summation if IVAR is present
-       """
-       if self.ivar==None:
-         self.ldata=makeflat(self.data, y1, y2)
-         #self.lvar=self.data[y1:y2,:].std(axis=0)
-         self.lvar=self.ldata
-       else:
-         self.lvar=((self.ivar[y1:y2,:]**2).sum(axis=0))
-         #self.ldata=(self.data[y1:y2,:]*self.ivar[y1:y2,:]).sum(axis=0)/self.lvar
-         self.ldata=makeflat(self.data, y1,y2)
-       return 
+    """A class for extracting a 1-D spectra from a 2-D image"""
 
+    def __init__(self, wave, data, ivar=None):
+        self.data = data
+        self.wave = wave
+        self.nwave = len(wave)
+        if ivar is None:
+            self.ivar = None
+        else:
+            self.ivar = ivar
+
+    def flatten(self, y1, y2):
+        """Compress the 2-D array down to 1-D. This is just either done by
+           a straight summation or by a weighted summation if IVAR is present
+        """
+        if self.ivar is None:
+            self.ldata = makeflat(self.data, y1, y2)
+            # self.lvar=self.data[y1:y2,:].std(axis=0)
+            self.lvar = self.ldata
+        else:
+            self.lvar = ((self.ivar[y1:y2, :] ** 2).sum(axis=0))
+            # self.ldata=(self.data[y1:y2,:]*self.ivar[y1:y2,:]).sum(axis=0)/self.lvar
+            self.ldata = makeflat(self.data, y1, y2)
+        return

--- a/PySpectrograph/Spectra/detectlines.py
+++ b/PySpectrograph/Spectra/detectlines.py
@@ -6,101 +6,104 @@
 import numpy as np
 from PySpectrograph import SpectrographError
 
-default_kernal=[0, -1, -2, -3, -2, -1, 0, 1, 2, 3, 2, 1, 0 ]
+default_kernal = [0, -1, -2, -3, -2, -1, 0, 1, 2, 3, 2, 1, 0]
+
 
 def centroid(xarr, yarr, kern=default_kernal, mask=None, mode='same'):
-   """Find the centroid of a line following a similar algorithm as
-       the center1d algorithm in IRAF.   xarr and yarr should be an area
-       around the desired feature to be centroided.  The default kernal
-       is used if the user does not specific one. 
+    """Find the centroid of a line following a similar algorithm as
+        the center1d algorithm in IRAF.   xarr and yarr should be an area
+        around the desired feature to be centroided.  The default kernal
+        is used if the user does not specific one.
 
-       The algorithm solves for the solution to the equation 
+        The algorithm solves for the solution to the equation
 
-       ..math:: \int (I-I_0) f(x-x_0) dx = 0
+        ..math:: \int (I-I_0) f(x-x_0) dx = 0
 
-       returns xc
-   """
-   if len(yarr)<len(kern):
-       raise SpectrographError('Array has to be larger than kernal')
+        returns xc
+    """
+    if len(yarr) < len(kern):
+        raise SpectrographError('Array has to be larger than kernal')
 
-   if mask is not None:
-       #catch the fact that at the edges it 
-       if mask.sum()<len(default_kernal):
-           warr=np.convolve(yarr, kern, mode=mode)
-           xc=np.interp(0, warr[mask], xarr[mask])
-           return xc
-       else:
-           yarr=yarr[mask]
-           xarr=xarr[mask]
+    if mask is not None:
+        # catch the fact that at the edges it
+        if mask.sum() < len(default_kernal):
+            warr = np.convolve(yarr, kern, mode=mode)
+            xc = np.interp(0, warr[mask], xarr[mask])
+            return xc
+        else:
+            yarr = yarr[mask]
+            xarr = xarr[mask]
 
-   #convle the input array with the default kernal
-   warr=np.convolve(yarr, kern, mode=mode)
+    # convle the input array with the default kernal
+    warr = np.convolve(yarr, kern, mode=mode)
 
-   #interpolate the results
-   xc=np.interp(0, warr, xarr)
+    # interpolate the results
+    xc = np.interp(0, warr, xarr)
 
-   return xc
+    return xc
 
 
 def detectlines(w_arr, f_arr, sigma=3, bsigma=None, niter=5, mask=None, kern=default_kernal, center=False):
-   """Detect lines goes through a 1-D spectra and detect peaks
+    """Detect lines goes through a 1-D spectra and detect peaks
 
-      w_arr--xaxis array (pixels, wavelength, etc)
-      f_arr--yaxis array (flux, counts, etc)
-      sigma--Threshold for detecting sources
-      bsigma--Threshold for determining background statistics
-      niter--iterations to determine background
-      center--return centroids and not pixels
-      mask--Pixels not to use
-   """
-   #set up the variables
-   if bsigma==None:
-      bsigma=sigma
+       w_arr--xaxis array (pixels, wavelength, etc)
+       f_arr--yaxis array (flux, counts, etc)
+       sigma--Threshold for detecting sources
+       bsigma--Threshold for determining background statistics
+       niter--iterations to determine background
+       center--return centroids and not pixels
+       mask--Pixels not to use
+    """
+    # set up the variables
+    if bsigma is None:
+        bsigma = sigma
 
-   if mask:
-       f_arr=f_arr[mask]
-       w_arr=w_arr[mask]
+    if mask:
+        f_arr = f_arr[mask]
+        w_arr = w_arr[mask]
 
-   #find all peaks
-   peaks=find_peaks(f_arr, sigma, niter, bsigma=bsigma)
+    # find all peaks
+    peaks = find_peaks(f_arr, sigma, niter, bsigma=bsigma)
 
-   #set the output values
-   xp=w_arr[peaks]
+    # set the output values
+    xp = w_arr[peaks]
 
-   if center:
-       xdiff=int(0.5*len(kern)+1)
-       x_arr=np.arange(len(w_arr))
-       xp=xp*1.0
-       for i in range(len(peaks)):
-           cmask=(abs(x_arr-peaks[i])<xdiff)
-           xp[i]=centroid(w_arr, f_arr, kern=kern, mask=cmask)
+    if center:
+        xdiff = int(0.5 * len(kern) + 1)
+        x_arr = np.arange(len(w_arr))
+        xp = xp * 1.0
+        for i in range(len(peaks)):
+            cmask = (abs(x_arr - peaks[i]) < xdiff)
+            xp[i] = centroid(w_arr, f_arr, kern=kern, mask=cmask)
 
-   return xp
+    return xp
+
 
 def find_peaks(f_arr, sigma, niter, bsigma=None):
-   """Go through an ordered array and find any element which is a peak"""
-   #set up the variables
-   if bsigma==None:
-      bsigma=sigma
+    """Go through an ordered array and find any element which is a peak"""
+    # set up the variables
+    if bsigma is None:
+        bsigma = sigma
 
-   #determine the background statistics
-   back_ave, back_std=find_backstats(f_arr, sigma, niter)
+    # determine the background statistics
+    back_ave, back_std = find_backstats(f_arr, sigma, niter)
 
-   #calculate the differences between the pixels
-   dfh=f_arr[1:-1]-f_arr[:-2]
-   dfl=f_arr[1:-1]-f_arr[2:]
+    # calculate the differences between the pixels
+    dfh = f_arr[1:-1] - f_arr[:-2]
+    dfl = f_arr[1:-1] - f_arr[2:]
 
-   #find the objects
-   mask=(dfh>0)*(dfl>0)*(abs(f_arr[1:-1]-back_ave)>back_std*sigma)
-   t=np.where(mask)[0]
-   return t+1
+    # find the objects
+    mask = (dfh > 0) * (dfl > 0) * (abs(f_arr[1:-1] - back_ave) > back_std * sigma)
+    t = np.where(mask)[0]
+    return t + 1
+
 
 def find_backstats(f_arr, sigma, niter):
-   """Iteratively calculate the statistics of an array"""
-   ave=f_arr.mean()
-   std=f_arr.std()
-   for i in range(niter):
-       mask=(abs(f_arr-ave)<sigma*std)
-       ave=f_arr[mask].mean()   
-       std=f_arr[mask].std()   
-   return ave, std
+    """Iteratively calculate the statistics of an array"""
+    ave = f_arr.mean()
+    std = f_arr.std()
+    for i in range(niter):
+        mask = (abs(f_arr - ave) < sigma * std)
+        ave = f_arr[mask].mean()
+        std = f_arr[mask].std()
+    return ave, std

--- a/PySpectrograph/Spectra/findobj.py
+++ b/PySpectrograph/Spectra/findobj.py
@@ -1,181 +1,186 @@
 #
-#detect objects in a 2-D spectra
+# detect objects in a 2-D spectra
 #
-#This is adopted from apextract
+# This is adopted from apextract
 #
 import math
 import numpy as np
 import scipy.ndimage as nd
 
-from PySpectrograph  import PySpectrographError
-
+from PySpectrograph import PySpectrographError
 
 
 def makeflat(data, method='median', specaxis=1):
-   """Comparess a 2-D array along the spectral axis
-      
-      data
+    """Comparess a 2-D array along the spectral axis
 
-   """
-   if method=='median':
-         return np.median(data, axis=specaxis)
-   elif method=='average':
-         return np.average(data, axis=specaxis)
-   elif method=='sum':
-         return np.sum(data, axis=specaxis)
-   else:
-       msg='%s is not method to flatten array'
-       raise PySpectrographError(msg)
+       data
+
+    """
+    if method == 'median':
+        return np.median(data, axis=specaxis)
+    elif method == 'average':
+        return np.average(data, axis=specaxis)
+    elif method == 'sum':
+        return np.sum(data, axis=specaxis)
+    else:
+        msg = '%s is not method to flatten array'
+        raise PySpectrographError(msg)
+
 
 def calc_ave_cont(data, method='sigclip', thresh=3.0, niter=5):
-   """Calculate the average level of the continuum with sig-clip rejection or via median absolute deviation.
-      If method is set to sigclip, it will return the sigma-clipped rejected mean and stardard deviation
-      given using the threshold and number of iterations
+    """Calculate the average level of the continuum with sig-clip rejection or via median absolute deviation.
+       If method is set to sigclip, it will return the sigma-clipped rejected mean and stardard deviation
+       given using the threshold and number of iterations
 
-      If method is mad, it will return the median and median absolute deviation for the data
+       If method is mad, it will return the median and median absolute deviation for the data
 
-      Returns mean, std
-   """
-   if method=='mad':
-      return np.median(data), np.median(abs(data-np.median(data)))
+       Returns mean, std
+    """
+    if method == 'mad':
+        return np.median(data), np.median(abs(data - np.median(data)))
 
-   ave=data.mean()
-   std=data.std()
-   for i in range(niter):
-       mask=abs(data-ave)<std*thresh
-       ave=data[mask].mean()
-       std=data[mask].std()
-   return ave, std  
+    ave = data.mean()
+    std = data.std()
+    for i in range(niter):
+        mask = abs(data - ave) < std * thresh
+        ave = data[mask].mean()
+        std = data[mask].std()
+    return ave, std
+
 
 def calc_med_cont(data):
-   """Calculate the median level of the continuum.  Std is based on MAD
+    """Calculate the median level of the continuum.  Std is based on MAD
 
-      Returns median, std
-   """
-   med=np.median(data)
-   std=1.4826*np.median(abs(data-med))
-   return med, std
-       
-def findObjects( data, specaxis=1, method='median', thresh=3.0, niter=5, minsize=3):
-   """Detect objects in the 2-D spectra 
-      data: 2D array of a spectral observations
-      specaxis: Axis of the dispersion
-      method: method for combining the array.  It can either be median, average, or sum
-      thresh:  Threshhold for object detection
-      niter:  Number of iterations
+       Returns median, std
+    """
+    med = np.median(data)
+    std = 1.4826 * np.median(abs(data - med))
+    return med, std
 
-      return  list of tuples
-   """
- 
-   #compress the data 
-   ldata=makeflat(data, method=method, specaxis=specaxis)
 
-   #median the data
-   ldata=nd.filters.median_filter(ldata, size=minsize)
+def findObjects(data, specaxis=1, method='median', thresh=3.0, niter=5, minsize=3):
+    """Detect objects in the 2-D spectra
+       data: 2D array of a spectral observations
+       specaxis: Axis of the dispersion
+       method: method for combining the array.  It can either be median, average, or sum
+       thresh:  Threshhold for object detection
+       niter:  Number of iterations
 
-   #determine the continuum values
-   cont_mean, cont_std=calc_ave_cont(ldata, method='mad')
+       return  list of tuples
+    """
 
-   return findLines(ldata, method=method, cont_mean=cont_mean, cont_std=cont_std,thresh=thresh, niter=niter, minsize=minsize)
+    # compress the data
+    ldata = makeflat(data, method=method, specaxis=specaxis)
+
+    # median the data
+    ldata = nd.filters.median_filter(ldata, size=minsize)
+
+    # determine the continuum values
+    cont_mean, cont_std = calc_ave_cont(ldata, method='mad')
+
+    return findLines(ldata, method=method, cont_mean=cont_mean, cont_std=cont_std,
+                     thresh=thresh, niter=niter, minsize=minsize)
+
 
 def findLines(ldata, method='median', cont_mean=None, cont_std=None, thresh=3.0, niter=5, minsize=3):
-   """Detect objects in 1-D spectra 
-      ldatl: 1D array of a spectral observations
-      specaxis: Axis of the dispersion
-      method: method for combining the array.  It can either be median, average, or sum
-      thresh:  Threshhold for object detection
-      niter:  Number of iterations
+    """Detect objects in 1-D spectra
+       ldatl: 1D array of a spectral observations
+       specaxis: Axis of the dispersion
+       method: method for combining the array.  It can either be median, average, or sum
+       thresh:  Threshhold for object detection
+       niter:  Number of iterations
 
-      return  list of tuples
-   """
+       return  list of tuples
+    """
 
-   #set the levels of the continuum 
-   if cont_mean is None or cont_std is None:
-       mean, std= calc_ave_cont(ldata)
-   if cont_mean is None: cont_mean=mean
-   if cont_std is None: cont_std=std
+    # set the levels of the continuum
+    if cont_mean is None or cont_std is None:
+        mean, std = calc_ave_cont(ldata)
+    if cont_mean is None:
+        cont_mean = mean
+    if cont_std is None:
+        cont_std = std
 
-   #detect the peakc in the distribution
-   obj_arr, obj_num=nd.label((abs(ldata-cont_mean)>thresh*cont_std))
+    # detect the peakc in the distribution
+    obj_arr, obj_num = nd.label((abs(ldata - cont_mean) > thresh * cont_std))
 
-   #determine the distributions
-   obj_list=[]
-   mag_list=[]
-     
-   #determine the boundries for all objects
-   for i in range(1,obj_num+1):
-       ind=np.where(obj_arr==i)[0]
-       my1=ind.min()
-       my2=ind.max()
-       if my2-my1> minsize and my1<my2:
-          objs=deblendObjects(ldata, my1, my2, thresh, niter, minsize)
-          for y1,y2 in objs:
-            if 0<y1<len(ldata) and 0< y2<len(ldata):
-              if y2<y1:  y1,y2=y2,y1
-              if y2==y1:  y2=y1+1
-              obj_list.append((y1,y2))
-              mag_list.append(ldata[y1:y2].max())
+    # determine the distributions
+    obj_list = []
+    mag_list = []
 
-           
-           
-   #sort the objects in magnitude order
-   ord_obj_list=[]
-   mag_arr=np.array(mag_list)
-   mag_id=mag_arr.argsort()
-   for i in mag_id[::-1]:
-       ord_obj_list.append(obj_list[i])
+    # determine the boundries for all objects
+    for i in range(1, obj_num + 1):
+        ind = np.where(obj_arr == i)[0]
+        my1 = ind.min()
+        my2 = ind.max()
+        if my2 - my1 > minsize and my1 < my2:
+            objs = deblendObjects(ldata, my1, my2, thresh, niter, minsize)
+            for y1, y2 in objs:
+                if 0 < y1 < len(ldata) and 0 < y2 < len(ldata):
+                    if y2 < y1:
+                        y1, y2 = y2, y1
+                    if y2 == y1:
+                        y2 = y1 + 1
+                    obj_list.append((y1, y2))
+                    mag_list.append(ldata[y1:y2].max())
 
+    # sort the objects in magnitude order
+    ord_obj_list = []
+    mag_arr = np.array(mag_list)
+    mag_id = mag_arr.argsort()
+    for i in mag_id[::-1]:
+        ord_obj_list.append(obj_list[i])
 
-   return ord_obj_list  
+    return ord_obj_list
+
 
 def deblendObjects(ldata, y1, y2, thresh=3.0, niter=5, minsize=3):
-   """Deblend a set of objects.  Deblend produces a list of y1,y2 for 
-          a an array created by scip.ndimages.label based on a set of data
+    """Deblend a set of objects.  Deblend produces a list of y1,y2 for
+           a an array created by scip.ndimages.label based on a set of data
 
-   """
+    """
 
-   #take the gradient of the data
-   gdata=np.gradient(ldata[y1:y2])
+    # take the gradient of the data
+    gdata = np.gradient(ldata[y1:y2])
 
-   #determine if there is more than one object 
-   try:
-      pos_ind=np.where(gdata>=0)[0].max()
-      neg_ind=np.where(gdata<=0)[0].min() 
-   except:
-      return [(y1,y2)]
-      
+    # determine if there is more than one object
+    try:
+        pos_ind = np.where(gdata >= 0)[0].max()
+        neg_ind = np.where(gdata <= 0)[0].min()
+    except:
+        return [(y1, y2)]
 
+    # If this is true, then there is only a single object to extract
+    if abs(pos_ind - neg_ind) < minsize:
+        return [(y1, y2)]
 
-   #If this is true, then there is only a single object to extract
-   if abs(pos_ind-neg_ind)<minsize:
-       return [(y1,y2)]
+    # manually go through the points and determine where it starts and stops
+    obj_list = []
+    dy1 = y1
+    neg = False
+    for i in range(len(gdata)):
+        if gdata[i] <= 0 and neg is False:
+            neg = True
+        if gdata[i] > 0 and neg is True:
+            dy2 = dy1 + i
+            obj_list.append((dy1, dy2))
+            dy1 = dy2 + 1
+            neg = False
+    obj_list.append((dy1, y2))
 
-   #manually go through the points and determine where it starts and stops
-   obj_list=[]
-   dy1=y1
-   neg=False
-   for i in range(len(gdata)):
-       if gdata[i]<=0 and neg is False:
-          neg=True
-       if gdata[i]>0 and neg is True:
-          dy2=dy1+i
-          obj_list.append((dy1,dy2))
-          dy1=dy2+1
-          neg=False
-   obj_list.append((dy1,y2))  
+    return obj_list
 
-   return obj_list 
 
 def plotdata(ldata, obj_arr):
     """Just for debuggin purposes"""
     from PySpectrograph.Utilities import makeplots
 
-    nlen=len(ldata)
-    x=np.arange(nlen)
-    makeplots.figure(figsize=(6,6),dpi=72)
-    ay=makeplots.axes([0.15,0.10,0.8,0.8])
+    nlen = len(ldata)
+    x = np.arange(nlen)
+    makeplots.figure(figsize=(6, 6), dpi=72)
+    ay = makeplots.axes([0.15, 0.10, 0.8, 0.8])
     #ay.imshow(med_data, cmap=makeplots.cm.gray, aspect='equal', vmin=-5, vmax=50  )
     makeplots.plotline(ay, x, np.gradient(ldata))
     #makeplots.plotline(ay, x, gdata)
-    makeplots.plotline(ay, x, obj_arr*100)
+    makeplots.plotline(ay, x, obj_arr * 100)
     makeplots.show()

--- a/PySpectrograph/Spectrograph/CCD.py
+++ b/PySpectrograph/Spectrograph/CCD.py
@@ -1,43 +1,44 @@
 import numpy as np
 
+
 class CCD:
-   """Defines a CCD by x and y position, size, and pixel size.  The x and y position are 
-      set such that they are zero relative to the detector position.  This assumes that 
-      the x and y positions are in the center of the pixels and that the ccd is symmetric.
 
-      pix_size is in mm
-   """
- 
-   def __init__(self, name='', height=0, width=0, xpos=0, ypos=0,            \
-                pix_size=0.015, xpix=2048, ypix=2048):
-       #set the variables
-       self.xpos=xpos
-       self.ypos=ypos
-       self.pix_size=pix_size 
-       self.xpix=xpix
-       self.ypix=ypix
-       self.height=self.set_height(height)
-       self.width=self.set_width(width)
-       
-   def set_width(self, w):
-       """If the width  is less than the number of pixels, then the width is
-          given by the number of pixels
-       """
-       min=self.xpix*self.pix_size 
-       return max(w,min)
+    """Defines a CCD by x and y position, size, and pixel size.  The x and y position are
+       set such that they are zero relative to the detector position.  This assumes that
+       the x and y positions are in the center of the pixels and that the ccd is symmetric.
 
-   def set_height(self, h):
-       """If the height is less than the number of pixels, then the height is
-          given by the number of pixels
-       """
-       min=self.ypix*self.pix_size   
-       return max(h,min)
+       pix_size is in mm
+    """
 
-   def find_corners(self):
-       """Return the corners of the ccd"""
-       x1=self.xpos-0.5*self.width
-       x2=self.xpos+0.5*self.width
-       y1=self.ypos-0.5*self.height
-       y2=self.ypos+0.5*self.height
-       return x1, x2, y1, y2
+    def __init__(self, name='', height=0, width=0, xpos=0, ypos=0,
+                 pix_size=0.015, xpix=2048, ypix=2048):
+        # set the variables
+        self.xpos = xpos
+        self.ypos = ypos
+        self.pix_size = pix_size
+        self.xpix = xpix
+        self.ypix = ypix
+        self.height = self.set_height(height)
+        self.width = self.set_width(width)
 
+    def set_width(self, w):
+        """If the width  is less than the number of pixels, then the width is
+           given by the number of pixels
+        """
+        min = self.xpix * self.pix_size
+        return max(w, min)
+
+    def set_height(self, h):
+        """If the height is less than the number of pixels, then the height is
+           given by the number of pixels
+        """
+        min = self.ypix * self.pix_size
+        return max(h, min)
+
+    def find_corners(self):
+        """Return the corners of the ccd"""
+        x1 = self.xpos - 0.5 * self.width
+        x2 = self.xpos + 0.5 * self.width
+        y1 = self.ypos - 0.5 * self.height
+        y2 = self.ypos + 0.5 * self.height
+        return x1, x2, y1, y2

--- a/PySpectrograph/Spectrograph/CreateImage.py
+++ b/PySpectrograph/Spectrograph/CreateImage.py
@@ -14,54 +14,67 @@ import numpy as np
 from PySpectrograph.Spectrograph import *
 from PySpectrograph.Spectra import *
 
+
 def writeout(arr, outfile):
-   #make and output the image
-   hdu = pyfits.PrimaryHDU(arr)
-   hdu.writeto(outfile)
+    # make and output the image
+    hdu = pyfits.PrimaryHDU(arr)
+    hdu.writeto(outfile)
 
 
 def CreateImage(spectrum, spec, xlen=None, ylen=None):
-   """CreateImage is a task  for creating a 2D spectrum of a source.
-      It creates a fits image of the source given pertinent information about
-      the spectrograph and spectrum
+    """CreateImage is a task  for creating a 2D spectrum of a source.
+       It creates a fits image of the source given pertinent information about
+       the spectrograph and spectrum
 
-      spectrum--an Spectrum object with information about the spectrum to plot
+       spectrum--an Spectrum object with information about the spectrum to plot
 
-      spec--a Spectrograph object describing a spectrograph
+       spec--a Spectrograph object describing a spectrograph
 
-      xlen--Optional length for the spetrograph detector.  If not, takes the information from spec
-   
-      ylen--Optional height for the spectrograph detector.  If not, take the information from spec
+       xlen--Optional length for the spetrograph detector.  If not, takes the information from spec
 
-   """
+       ylen--Optional height for the spectrograph detector.  If not, take the information from spec
 
-   #Set up the detector array--this is the output image
-   if xlen is None:
-      xlen=int(spec.detector.width/spec.detector.xbin/spec.detector.pix_size)
-   else:
-      xlen=xlen
+    """
 
-   if ylen is None:
-      ylen=int(spec.detector.height/spec.detector.ybin/spec.detector.pix_size)
-   else:
-      ylen=ylen
+    # Set up the detector array--this is the output image
+    if xlen is None:
+        xlen = int(spec.detector.width / spec.detector.xbin / spec.detector.pix_size)
+    else:
+        xlen = xlen
 
-   #set up the arrays
-   x_arr=np.arange(xlen)
-   y_arr=np.arange(ylen)
-   arr=np.zeros((ylen, xlen))
+    if ylen is None:
+        ylen = int(spec.detector.height / spec.detector.ybin / spec.detector.pix_size)
+    else:
+        ylen = ylen
 
-   #Convert the spectrum into pixel space
-   alpha=spec.gratang
-   beta=spec.gratang-spec.camang
-   dw=0.5*1e7*spec.calc_resolelement(alpha, beta)
-   dx=spec.detector.xpos/(spec.detector.xbin*spec.detector.pix_scale)
-   dy=spec.detector.ypos/(spec.detector.ybin*spec.detector.pix_scale)
-   dbeta=np.degrees(np.arctan(spec.detector.xbin*spec.detector.pix_size*(x_arr-0.5*x_arr.max()+dx)/spec.camera.focallength))
+    # set up the arrays
+    x_arr = np.arange(xlen)
+    y_arr = np.arange(ylen)
+    arr = np.zeros((ylen, xlen))
 
-   for j in y_arr:
-       gamma=np.degrees(np.arctan(spec.detector.ybin*spec.detector.pix_size*(j-0.5*y_arr.max()+dy)/spec.camera.focallength))
-       w_arr=1e7*spec.calc_wavelength(alpha, beta-dbeta, gamma=gamma)
-       arr[j,x_arr]=np.interp(w_arr, spectrum.wavelength, spectrum.set_dispersion(dw, nkern=50))
+    # Convert the spectrum into pixel space
+    alpha = spec.gratang
+    beta = spec.gratang - spec.camang
+    dw = 0.5 * 1e7 * spec.calc_resolelement(alpha, beta)
+    dx = spec.detector.xpos / (spec.detector.xbin * spec.detector.pix_scale)
+    dy = spec.detector.ypos / (spec.detector.ybin * spec.detector.pix_scale)
+    dbeta = np.degrees(np.arctan(spec.detector.xbin *
+                                 spec.detector.pix_size *
+                                 (x_arr -
+                                  0.5 *
+                                  x_arr.max() +
+                                     dx) /
+                                 spec.camera.focallength))
 
-   return arr
+    for j in y_arr:
+        gamma = np.degrees(np.arctan(spec.detector.ybin *
+                                     spec.detector.pix_size *
+                                     (j -
+                                      0.5 *
+                                      y_arr.max() +
+                                         dy) /
+                                     spec.camera.focallength))
+        w_arr = 1e7 * spec.calc_wavelength(alpha, beta - dbeta, gamma=gamma)
+        arr[j, x_arr] = np.interp(w_arr, spectrum.wavelength, spectrum.set_dispersion(dw, nkern=50))
+
+    return arr

--- a/PySpectrograph/Spectrograph/Detector.py
+++ b/PySpectrograph/Spectrograph/Detector.py
@@ -1,152 +1,155 @@
 import numpy as np
-from CCD import CCD
+from .CCD import CCD
 
 
 class Detector(CCD):
-   """A class that describing the Detector.  It inherets from the CCD class as there could be
-      multiple ccds at each position.
 
-      name--Name of the detector
-      ccd--a CCD class or list describing the CCDs in the detecfor
-      xpos--Offset of the x center of the ccd from the central ray in mm
-      ypos--Offset of the y center of the ccd from the central ray in mm
-      zpos--Offset of the z center of the ccd from the central ray in mm
-      xbin--ccd binning in x-direction
-      ybin--ccd binning in y-direction
-      plate_scale--plate scale in mm/" 
-   """
+    """A class that describing the Detector.  It inherets from the CCD class as there could be
+       multiple ccds at each position.
 
-   def __init__(self, name='', ccd=CCD(), zpos=0, xpos=0, ypos=0, xbin=2, ybin=2, plate_scale=0.224):
-      
-       #Set the detector up as a list of CCDs.  
-       self.detector=[]
-       self.pix_size = None 
-       if isinstance(ccd, CCD):
-           self.detector=[ccd]
-           self.pix_size =ccd.pix_size 
-       elif isinstance(ccd, list):
-           for c in ccd:
-               if isinstance(c, CCD):
-                   self.detector.append(c)
-                   if self.pix_size :
-                      self.pix_size =min(self.pix_size , c.pix_size )
-                   else:
-                      self.pix_size =c.pix_size 
-       else:
-           return 
+       name--Name of the detector
+       ccd--a CCD class or list describing the CCDs in the detecfor
+       xpos--Offset of the x center of the ccd from the central ray in mm
+       ypos--Offset of the y center of the ccd from the central ray in mm
+       zpos--Offset of the z center of the ccd from the central ray in mm
+       xbin--ccd binning in x-direction
+       ybin--ccd binning in y-direction
+       plate_scale--plate scale in mm/"
+    """
 
-       self.nccd=len(self.detector)
- 
-       #set up the zero points for the detector
-       self.name = name
-       self.zpos=zpos
-       self.xpos=xpos
-       self.ypos=ypos
-       self.xbin=xbin
-       self.ybin=ybin
-       self.plate_scale=plate_scale
-       self.pix_scale=self.plate_scale/self.pix_size
+    def __init__(self, name='', ccd=CCD(), zpos=0, xpos=0, ypos=0, xbin=2, ybin=2, plate_scale=0.224):
 
+        # Set the detector up as a list of CCDs.
+        self.detector = []
+        self.pix_size = None
+        if isinstance(ccd, CCD):
+            self.detector = [ccd]
+            self.pix_size = ccd.pix_size
+        elif isinstance(ccd, list):
+            for c in ccd:
+                if isinstance(c, CCD):
+                    self.detector.append(c)
+                    if self.pix_size:
+                        self.pix_size = min(self.pix_size, c.pix_size)
+                    else:
+                        self.pix_size = c.pix_size
+        else:
+            return
 
-       #check to make sure that the ccds don't overlap
-       self.real=self.check_ccds()
+        self.nccd = len(self.detector)
 
-       #determine the max width and height for the detector
-       self.width=self.find_width()
+        # set up the zero points for the detector
+        self.name = name
+        self.zpos = zpos
+        self.xpos = xpos
+        self.ypos = ypos
+        self.xbin = xbin
+        self.ybin = ybin
+        self.plate_scale = plate_scale
+        self.pix_scale = self.plate_scale / self.pix_size
 
-       #determine the max width and height for the detector
-       self.height=self.find_height()
+        # check to make sure that the ccds don't overlap
+        self.real = self.check_ccds()
 
+        # determine the max width and height for the detector
+        self.width = self.find_width()
 
-   def check_ccds(self):
-       """Check to make sure none of the ccds overlap"""
-       if self.nccd<=1: return True
+        # determine the max width and height for the detector
+        self.height = self.find_height()
 
-       #loop over each ccd and check to see if any of the ccd
-       #overlaps with the coordinates of another ccd
-       for i in range(self.nccd):
-           ax1, ax2, ay1, ay2=self.detector[i].find_corners()
-           for j in range(i+1,self.nccd):
-               bx1, bx2, by1, by2=self.detector[j].find_corners()
-               if ax1 <= bx1 < ax2 or ax1 < bx2 < ax2:
-                   if ay1 <= by1 < ay2 or ay1 < by2 < ay2:
-                       return False
+    def check_ccds(self):
+        """Check to make sure none of the ccds overlap"""
+        if self.nccd <= 1:
+            return True
 
-       return True
+        # loop over each ccd and check to see if any of the ccd
+        # overlaps with the coordinates of another ccd
+        for i in range(self.nccd):
+            ax1, ax2, ay1, ay2 = self.detector[i].find_corners()
+            for j in range(i + 1, self.nccd):
+                bx1, bx2, by1, by2 = self.detector[j].find_corners()
+                if ax1 <= bx1 < ax2 or ax1 < bx2 < ax2:
+                    if ay1 <= by1 < ay2 or ay1 < by2 < ay2:
+                        return False
 
-   def get_xpixcenter(self):
-       """Return the xpixel center based on the x and y position"""
-       return int((0.5*self.find_width()-self.xpos)/self.pix_size/self.xbin)
+        return True
 
-   def get_ypixcenter(self):
-       """Return the xpixel center based on the x and y position"""
-       return int((0.5*self.find_height()-self.ypos)/self.pix_size/self.ybin)
- 
-   def find_width(self):
-       """Loop over all the ccds in detector and find the width"""
-       width=0
-       #return zero if no detector
-       if self.nccd<1: return width
+    def get_xpixcenter(self):
+        """Return the xpixel center based on the x and y position"""
+        return int((0.5 * self.find_width() - self.xpos) / self.pix_size / self.xbin)
 
-       #handle a single detector
-       width=self.detector[0].width
-       if self.nccd==1: return width
+    def get_ypixcenter(self):
+        """Return the xpixel center based on the x and y position"""
+        return int((0.5 * self.find_height() - self.ypos) / self.pix_size / self.ybin)
 
-       #Loop over multipe CCDs to find the width
-       ax1, ax2, ay1, ay2=self.detector[0].find_corners()
-       xmin=min(ax1, ax2)
-       xmax=max(ax1, ax2)
-       for ccd in self.detector[1:]:
-            ax1, ax2, ay1, ay2=ccd.find_corners()
-            xmin=min(xmin, ax1, ax2)
-            xmax=max(xmax, ax1, ax2)
-       return xmax-xmin
+    def find_width(self):
+        """Loop over all the ccds in detector and find the width"""
+        width = 0
+        # return zero if no detector
+        if self.nccd < 1:
+            return width
 
-   def find_height(self):
-       """Loop over all the ccds in detector and find the height"""
-       height=0
-       #return zero if no detector
-       if self.nccd<1: return height
+        # handle a single detector
+        width = self.detector[0].width
+        if self.nccd == 1:
+            return width
 
-       #handle a single detector
-       height=self.detector[0].height
-       if self.nccd==1: return height
+        # Loop over multipe CCDs to find the width
+        ax1, ax2, ay1, ay2 = self.detector[0].find_corners()
+        xmin = min(ax1, ax2)
+        xmax = max(ax1, ax2)
+        for ccd in self.detector[1:]:
+            ax1, ax2, ay1, ay2 = ccd.find_corners()
+            xmin = min(xmin, ax1, ax2)
+            xmax = max(xmax, ax1, ax2)
+        return xmax - xmin
 
-       #Loop over multipe CCDs to find the width
-       ax1, ax2, ay1, ay2=self.detector[0].find_corners()
-       ymin=min(ay1, ay2)
-       ymax=max(ay1, ay2)
-       for ccd in self.detector[1:]:
-            ax1, ax2, ay1, ay2=ccd.find_corners()
-            ymin=min(ymin, ay1, ay2)
-            ymax=max(ymax, ay1, ay2)
-       height=ymax-ymin
-       return height 
+    def find_height(self):
+        """Loop over all the ccds in detector and find the height"""
+        height = 0
+        # return zero if no detector
+        if self.nccd < 1:
+            return height
 
-   def make_detector(self):
-       """Given the information about the detector, return an array with values of
-          either 1 or 0 for where the CCDs are
-       """
-       
-       #find the minimum pixel scale and set the number of pixels
-       xps=self.xbin*self.pix_size 
-       yps=self.ybin*self.pix_size 
-       pw=round(self.width/xps)
-       ph=round(self.height/yps)
+        # handle a single detector
+        height = self.detector[0].height
+        if self.nccd == 1:
+            return height
 
-       #create the array
-       arr=np.zeros((ph, pw), dtype=float)
-       y, x = np.indices((ph, pw))
+        # Loop over multipe CCDs to find the width
+        ax1, ax2, ay1, ay2 = self.detector[0].find_corners()
+        ymin = min(ay1, ay2)
+        ymax = max(ay1, ay2)
+        for ccd in self.detector[1:]:
+            ax1, ax2, ay1, ay2 = ccd.find_corners()
+            ymin = min(ymin, ay1, ay2)
+            ymax = max(ymax, ay1, ay2)
+        height = ymax - ymin
+        return height
 
-       #set up where the detectors are
-       for ccd in self.detector:
-           x1,x2,y1,y2=ccd.find_corners()
-           x1=(x1+0.5*self.width)/xps
-           x2=(x2+0.5*self.width)/xps
-           y1=(y1+0.5*self.height)/yps
-           y2=(y2+0.5*self.height)/yps
-           mask=(x1<=x)*(x<x2)*(y1<=y)*(y<y2)
-           arr[mask]=1
-      
-       return arr
+    def make_detector(self):
+        """Given the information about the detector, return an array with values of
+           either 1 or 0 for where the CCDs are
+        """
 
+        # find the minimum pixel scale and set the number of pixels
+        xps = self.xbin * self.pix_size
+        yps = self.ybin * self.pix_size
+        pw = round(self.width / xps)
+        ph = round(self.height / yps)
+
+        # create the array
+        arr = np.zeros((ph, pw), dtype=float)
+        y, x = np.indices((ph, pw))
+
+        # set up where the detectors are
+        for ccd in self.detector:
+            x1, x2, y1, y2 = ccd.find_corners()
+            x1 = (x1 + 0.5 * self.width) / xps
+            x2 = (x2 + 0.5 * self.width) / xps
+            y1 = (y1 + 0.5 * self.height) / yps
+            y2 = (y2 + 0.5 * self.height) / yps
+            mask = (x1 <= x) * (x < x2) * (y1 <= y) * (y < y2)
+            arr[mask] = 1
+
+        return arr

--- a/PySpectrograph/Spectrograph/Grating.py
+++ b/PySpectrograph/Spectrograph/Grating.py
@@ -1,24 +1,23 @@
 
 
-
 class Grating:
-   """A class that describing gratings.  Sigma should be in lines/mm and the 
-      units of the dimensions should be mm.
-   """
-   
-   def __init__(self, name='', spacing=600, order=1, height=100, width=100,    \
-                thickness=100, blaze=0, type='transmission'):
-       #define the variables that describe the grating
-       self.order  = order
-       self.height = height
-       self.width  = width 
-       self.thickness = thickness
-       self.sigma = 1.0/spacing
-       self.blaze = blaze
-       self.name = name
-       self.type=type
-       #set the sign for the grating equation
-       self.sign=1
-       if self.type=='transmission': 
-          self.sign=-1
 
+    """A class that describing gratings.  Sigma should be in lines/mm and the
+       units of the dimensions should be mm.
+    """
+
+    def __init__(self, name='', spacing=600, order=1, height=100, width=100,
+                 thickness=100, blaze=0, type='transmission'):
+        # define the variables that describe the grating
+        self.order = order
+        self.height = height
+        self.width = width
+        self.thickness = thickness
+        self.sigma = 1.0 / spacing
+        self.blaze = blaze
+        self.name = name
+        self.type = type
+        # set the sign for the grating equation
+        self.sign = 1
+        if self.type == 'transmission':
+            self.sign = -1

--- a/PySpectrograph/Spectrograph/Optics.py
+++ b/PySpectrograph/Spectrograph/Optics.py
@@ -1,34 +1,34 @@
 
 
-
 class Optics:
-   """A class that describing optics.  All dimensions should in mm.  This assumes all optics
-      can be desribed by a diameter and focal length. zpos is the distance in mm that the center
-      of the optic is from the primary mirror.   focas is the offset from that position
-   """
-   
-   def __init__(self, name='', diameter=100, focallength=100, width=100,    \
-                zpos=0, focus=0):
-       #define the variables that describe the opticsg
-       self.diameter=diameter 
-       self.focallength=focallength
-       self.width = width
-       self.name = name
-       #set distances of the optics
-       self.zpos=zpos
-       self.focus=focus
 
-   def speed(self):
-       """Camera Speed f/ = d/f
-       """
-       return self.diameter/self.focallength
+    """A class that describing optics.  All dimensions should in mm.  This assumes all optics
+       can be desribed by a diameter and focal length. zpos is the distance in mm that the center
+       of the optic is from the primary mirror.   focas is the offset from that position
+    """
 
-   def platescale(self):
-       """Plate scale for a given optic in arcsec/mm
-       """
-       return 206265/self.focallength
-      
-   def position(self):
-       """Current position along the optical path of the element
-       """
-       return self.zpos+self.focus
+    def __init__(self, name='', diameter=100, focallength=100, width=100,
+                 zpos=0, focus=0):
+        # define the variables that describe the opticsg
+        self.diameter = diameter
+        self.focallength = focallength
+        self.width = width
+        self.name = name
+        # set distances of the optics
+        self.zpos = zpos
+        self.focus = focus
+
+    def speed(self):
+        """Camera Speed f/ = d/f
+        """
+        return self.diameter / self.focallength
+
+    def platescale(self):
+        """Plate scale for a given optic in arcsec/mm
+        """
+        return 206265 / self.focallength
+
+    def position(self):
+        """Current position along the optical path of the element
+        """
+        return self.zpos + self.focus

--- a/PySpectrograph/Spectrograph/Slit.py
+++ b/PySpectrograph/Spectrograph/Slit.py
@@ -1,38 +1,36 @@
 import math
 
+
 class Slit:
-   """A class that describing the slit.  Only assuming a single slit.  All sizes are in mm.
-      All positions assume the center of the slit. Phi is in arcseconds
-   """
 
-   def __init__(self, name='', height=100, width=100, zpos=0, xpos=0, ypos=0, phi=1):
+    """A class that describing the slit.  Only assuming a single slit.  All sizes are in mm.
+       All positions assume the center of the slit. Phi is in arcseconds
+    """
 
-       #define the variables that describe the grating
-       self.height = height
-       self.width  = width 
-       self.name = name
-       self.zpos=zpos
-       self.xpos=xpos
-       self.ypos=ypos
-       self.phi=phi
-       
+    def __init__(self, name='', height=100, width=100, zpos=0, xpos=0, ypos=0, phi=1):
 
-   def set_phi(self, phi):
-       self.phi=phi
+        # define the variables that describe the grating
+        self.height = height
+        self.width = width
+        self.name = name
+        self.zpos = zpos
+        self.xpos = xpos
+        self.ypos = ypos
+        self.phi = phi
 
-   def calc_phi(self, ftel):
-       """Calculate phi(angle on sky) assuming w/ftel
+    def set_phi(self, phi):
+        self.phi = phi
 
-          returns phi in arcseconds
-       """
-       return 3600.0*math.degrees(self.width/ftel)
+    def calc_phi(self, ftel):
+        """Calculate phi(angle on sky) assuming w/ftel
 
-   def calc_width(self, ftel):
-       """Calculate the width assuming ftel*phi(rad).  
+           returns phi in arcseconds
+        """
+        return 3600.0 * math.degrees(self.width / ftel)
 
-          returns the slit width in mm
-       """
-       return ftel*math.radians(self.phi/3600.0)
+    def calc_width(self, ftel):
+        """Calculate the width assuming ftel*phi(rad).
 
-
-
+           returns the slit width in mm
+        """
+        return ftel * math.radians(self.phi / 3600.0)

--- a/PySpectrograph/Spectrograph/Spectrograph.py
+++ b/PySpectrograph/Spectrograph/Spectrograph.py
@@ -13,147 +13,146 @@ Limitations:
 
 import math
 
-from SpectrographEquations import *
-from Grating import Grating
-from Optics import Optics
-from Slit import Slit
-from Detector import Detector
-from CCD import CCD
-
+from .SpectrographEquations import *
+from .Grating import Grating
+from .Optics import Optics
+from .Slit import Slit
+from .Detector import Detector
+from .CCD import CCD
 
 
 class Spectrograph(Grating, Optics, Slit, Detector):
-   """A class describing a spectrograph and functions 
-      related to a spectrograph.  All angles are in degrees.
-   """
- 
-   def __init__(self, camang=45, gratang=45, grating=Grating(), camera=Optics(),\
-                collimator=Optics(), telescope=Optics(), slit=Slit(),           \
-                detector=Detector()):  
 
-       #initiate the grating
-       self.grating=grating 
- 
-       #initiate the telescope
-       self.telescope=telescope
- 
-       #initiate the collimator
-       self.collimator=collimator
+    """A class describing a spectrograph and functions
+       related to a spectrograph.  All angles are in degrees.
+    """
 
-       #initiate the camera
-       self.camera=camera
-       
-       #initiate the slit
-       self.slit=slit
- 
-       #initiate the detector
-       self.detector=detector
-       
-       #set up the angles in the system
-       self.gratang=gratang
-       self.camang=camang
-       
-       return
+    def __init__(self, camang=45, gratang=45, grating=Grating(), camera=Optics(),
+                 collimator=Optics(), telescope=Optics(), slit=Slit(),
+                 detector=Detector()):
 
-   def alpha(self):
-       return self.gratang
+        # initiate the grating
+        self.grating = grating
 
-   def beta(self):
-       return self.camang-self.gratang
+        # initiate the telescope
+        self.telescope = telescope
 
-   def gamma(self):
-       return self.gamma
+        # initiate the collimator
+        self.collimator = collimator
 
-   def calc_wavelength(self, alpha, beta, gamma=0.0, nd=n_index):
-       """Apply the grating equation to determine the wavelength
-          returns wavelength in mm
-       """
-       w=gratingequation(self.grating.sigma,self.grating.order, self.grating.sign, alpha, beta, gamma=gamma, nd=nd)
-       return w
+        # initiate the camera
+        self.camera = camera
 
-   def calc_angdisp(self, beta):
-       """Calculate the angular dispersion according to m/sigma/cos beta 
+        # initiate the slit
+        self.slit = slit
 
-          returns angular dispersion in 1/mm
-       """
-       A=calc_angdisp(self.grating.sigma, self.grating.order, beta)
-       return A
+        # initiate the detector
+        self.detector = detector
 
-   def calc_lindisp(self, beta): 
-       """Calculate the linear dispersion according to f_cam * A 
+        # set up the angles in the system
+        self.gratang = gratang
+        self.camang = camang
 
-          return linear dispersion in mm/mm
+        return
 
-       """
-       return calc_lindisp(self.camera.focallength,self.grating.sigma, self.grating.order, beta)
+    def alpha(self):
+        return self.gratang
 
-   def calc_demagspatial(self):
-       """Calculate the spatial demagnification
-         
-          returns the spatial demagnification
-       """
-       return calc_demagspatial(self.collimator.focallength,self.camera.focallength)
+    def beta(self):
+        return self.camang - self.gratang
 
-   def calc_demagspectral(self, alpha, beta):
-       """Calculate the spectral demagnification
-         
-          returns the spectral demagnification
-       """
-       return self.calc_demagspatial()/se.calc_anamorph(alpha, beta)
+    def gamma(self):
+        return self.gamma
 
-   def calc_spatslitimage(self):
-       """Calculate the spatial extant of the slit image
-         
-          return in mm
-       """
-       return self.slit.width/self.calc_demagspatial()
+    def calc_wavelength(self, alpha, beta, gamma=0.0, nd=n_index):
+        """Apply the grating equation to determine the wavelength
+           returns wavelength in mm
+        """
+        w = gratingequation(self.grating.sigma, self.grating.order, self.grating.sign, alpha, beta, gamma=gamma, nd=nd)
+        return w
 
-   def calc_specslitimage(self, beta):
-       """Calculate the spectral extant of the slit image
-         
-          return in mm
-       """
-       return self.slit.width*self.calc_lindisp(beta)
+    def calc_angdisp(self, beta):
+        """Calculate the angular dispersion according to m/sigma/cos beta
 
-   def calc_resolelement(self, alpha, beta):
-       """Calculate the resolution of a single element for a filled slit
- 
-          return the wavelength resolution in mm
-       """
-       dw=calc_resolelement(self.slit.width, self.collimator.focallength,   \
-                               self.grating.sigma, self.grating.order,         \
-                               alpha, beta )
-       return dw
+           returns angular dispersion in 1/mm
+        """
+        A = calc_angdisp(self.grating.sigma, self.grating.order, beta)
+        return A
 
-   def calc_resolution(self, w, alpha, beta):
-       """Calculate the resolution at a given wavelength.  w/dw
-          
-          returns resolution
-       """
-       return w/self.calc_resolelement(alpha, beta)
+    def calc_lindisp(self, beta):
+        """Calculate the linear dispersion according to f_cam * A
 
-   def calc_centralwavelength(self):  
-       """Calculate the central wavlength
-    
-          return waveleng in mm
-       """
-       return self.calc_wavelength(self.alpha(), -self.beta())
+           return linear dispersion in mm/mm
 
-   def calc_redwavelength(self):
-       """For the detector, calculate the maximum red wavelength
-          Assume just the width of the detector
-  
-          return waveleng in mm
-       """
-       dbeta=math.degrees(math.atan(0.5*self.detector.width/self.camera.focallength))
-       return self.calc_wavelength(self.alpha(), -self.beta()-dbeta)
+        """
+        return calc_lindisp(self.camera.focallength, self.grating.sigma, self.grating.order, beta)
 
-   def calc_bluewavelength(self):
-       """For the detector, calculate the maximum blue wavelength
-          Assume just the width of the detector
-  
-          return waveleng in mm
-       """
-       dbeta=math.degrees(math.atan(0.5*self.detector.width/self.camera.focallength))
-       return self.calc_wavelength(self.alpha(), -self.beta()+dbeta)
+    def calc_demagspatial(self):
+        """Calculate the spatial demagnification
 
+           returns the spatial demagnification
+        """
+        return calc_demagspatial(self.collimator.focallength, self.camera.focallength)
+
+    def calc_demagspectral(self, alpha, beta):
+        """Calculate the spectral demagnification
+
+           returns the spectral demagnification
+        """
+        return self.calc_demagspatial() / se.calc_anamorph(alpha, beta)
+
+    def calc_spatslitimage(self):
+        """Calculate the spatial extant of the slit image
+
+           return in mm
+        """
+        return self.slit.width / self.calc_demagspatial()
+
+    def calc_specslitimage(self, beta):
+        """Calculate the spectral extant of the slit image
+
+           return in mm
+        """
+        return self.slit.width * self.calc_lindisp(beta)
+
+    def calc_resolelement(self, alpha, beta):
+        """Calculate the resolution of a single element for a filled slit
+
+           return the wavelength resolution in mm
+        """
+        dw = calc_resolelement(self.slit.width, self.collimator.focallength,
+                               self.grating.sigma, self.grating.order,
+                               alpha, beta)
+        return dw
+
+    def calc_resolution(self, w, alpha, beta):
+        """Calculate the resolution at a given wavelength.  w/dw
+
+           returns resolution
+        """
+        return w / self.calc_resolelement(alpha, beta)
+
+    def calc_centralwavelength(self):
+        """Calculate the central wavlength
+
+           return waveleng in mm
+        """
+        return self.calc_wavelength(self.alpha(), -self.beta())
+
+    def calc_redwavelength(self):
+        """For the detector, calculate the maximum red wavelength
+           Assume just the width of the detector
+
+           return waveleng in mm
+        """
+        dbeta = math.degrees(math.atan(0.5 * self.detector.width / self.camera.focallength))
+        return self.calc_wavelength(self.alpha(), -self.beta() - dbeta)
+
+    def calc_bluewavelength(self):
+        """For the detector, calculate the maximum blue wavelength
+           Assume just the width of the detector
+
+           return waveleng in mm
+        """
+        dbeta = math.degrees(math.atan(0.5 * self.detector.width / self.camera.focallength))
+        return self.calc_wavelength(self.alpha(), -self.beta() + dbeta)

--- a/PySpectrograph/Spectrograph/SpectrographEquations.py
+++ b/PySpectrograph/Spectrograph/SpectrographEquations.py
@@ -1,77 +1,83 @@
 
 from PySpectrograph.Utilities.degreemath import cosd, sind
 
+
 def n_index():
     return 1.0000
 
+
 def gratingequation(sigma, order, sign, alpha, beta, gamma=0, nd=n_index):
-   """Apply the grating equation to determine the wavelength
-      w = sigma/m cos (gamma) * n_ind *(sin alpha +- sin beta)
-  
-      returns wavelength in mm
-   """
-   angle=cosd(gamma)*nd()*(sind(alpha)+sign*sind(beta))
-   return sigma/order*angle
+    """Apply the grating equation to determine the wavelength
+       w = sigma/m cos (gamma) * n_ind *(sin alpha +- sin beta)
+
+       returns wavelength in mm
+    """
+    angle = cosd(gamma) * nd() * (sind(alpha) + sign * sind(beta))
+    return sigma / order * angle
+
 
 def calc_angdisp(sigma, order, beta, gamma=0):
-   """Calculate the angular dispersion according to m/sigma/cos beta 
+    """Calculate the angular dispersion according to m/sigma/cos beta
 
-      returns angular dispersion in 1/mm
-   """
-   return order/sigma/cosd(beta)/cosd(gamma)
+       returns angular dispersion in 1/mm
+    """
+    return order / sigma / cosd(beta) / cosd(gamma)
+
 
 def calc_lindisp(f, sigma, order, beta, gamma=0.0):
-   """Calculate the linear dispersion according to f_cam * A 
+    """Calculate the linear dispersion according to f_cam * A
 
-      return linear dispersion in mm/mm
+       return linear dispersion in mm/mm
 
-   """
-   return f*calc_angdisp(sigma, order, beta, gamma=gamma)
+    """
+    return f * calc_angdisp(sigma, order, beta, gamma=gamma)
 
 
 def calc_anamorph(alpha, beta):
-   """Calculates the anamorphic magnification
+    """Calculates the anamorphic magnification
 
-      returns the anamorpic magnification
-   """
-   return cosd(alpha)/cosd(beta)
+       returns the anamorpic magnification
+    """
+    return cosd(alpha) / cosd(beta)
 
 
 def calc_demagspatial(fcol, fcam):
-   """Calculate the spatial demagnification
-         
-          returns the spatial demagnification
-   """
-   return fcol/fcam
+    """Calculate the spatial demagnification
+
+           returns the spatial demagnification
+    """
+    return fcol / fcam
+
 
 def calc_demagspectral(fcol, fcam, alpha, beta):
-   """Calculate the spectral demagnification
-         
-      returns the spectral demagnification
-   """
-   return calc_demagspatial(fcol, fcam)/calc_anamorph(alpha, beta)
+    """Calculate the spectral demagnification
 
-   
-def calc_resolelement(w, fcol, sigma, order, alpha, beta, gamma=0.0 ):
-   """Calculate the resolution element using dw=r*w/A/fcol
+       returns the spectral demagnification
+    """
+    return calc_demagspatial(fcol, fcam) / calc_anamorph(alpha, beta)
 
-      returns resolution element in mm
-   """
-   r=calc_anamorph(alpha, beta)
-   A=calc_angdisp(sigma, order, beta, gamma=gamma)
-   return _calc_resolelement(w,fcol, r, A)
+
+def calc_resolelement(w, fcol, sigma, order, alpha, beta, gamma=0.0):
+    """Calculate the resolution element using dw=r*w/A/fcol
+
+       returns resolution element in mm
+    """
+    r = calc_anamorph(alpha, beta)
+    A = calc_angdisp(sigma, order, beta, gamma=gamma)
+    return _calc_resolelement(w, fcol, r, A)
+
 
 def _calc_resolelement(w, fcol, r, A):
-   """Calculate the resolution element using dw=r*w/A/fcol
+    """Calculate the resolution element using dw=r*w/A/fcol
 
-      returns resolution element in mm
-   """
-   return r*w/A/fcol
+       returns resolution element in mm
+    """
+    return r * w / A / fcol
+
 
 def calc_resolution(w, dw):
     """Calcualte the resolution R=w/dw
 
        returns the resolution
     """
-    return w/dw
-
+    return w / dw

--- a/PySpectrograph/Spectrograph/__init__.py
+++ b/PySpectrograph/Spectrograph/__init__.py
@@ -1,5 +1,5 @@
 """Spectrograph package is part of PySpectrograph and provides
-a model for a grating spectrograph. 
+a model for a grating spectrograph.
 
 This task includes:
 
@@ -7,15 +7,14 @@ Spectrograph--The basic equations and components of a spectrograph
 Models--models for different spectrographs
 Spectra--classes for the handling of spectra
 WavelengthSolutions--Methods for calculating the wavelength solution
-Identify--Tasks to measure the wavelength solution 
+Identify--Tasks to measure the wavelength solution
 Utilities--General useful tasks
 
 """
 
-from Spectrograph import Spectrograph
-from Grating import Grating
-from Optics import Optics
-from Slit import Slit
-from Detector import Detector
-from CCD import CCD
-
+from .Spectrograph import Spectrograph
+from .Grating import Grating
+from .Optics import Optics
+from .Slit import Slit
+from .Detector import Detector
+from .CCD import CCD

--- a/PySpectrograph/Utilities/Functions.py
+++ b/PySpectrograph/Utilities/Functions.py
@@ -9,58 +9,58 @@ Limitations:
 """
 import numpy as np
 
+
 class FunctionsError(Exception):
-   """Exception Raised for Function errors"""
-   pass
+
+    """Exception Raised for Function errors"""
+    pass
 
 
 def Normal(arr, mean, sigma, scale=1):
-   """Return the normal distribution of N dimensions
-     
-      arr--The input array of N dimensions
-      mean--the mean of the distribution--either a scalor or N-dimensional array
-      sigma--the std deviation of the distribution--either a scalor or N-dimensial array
-      scale--the scale of the distrubion
+    """Return the normal distribution of N dimensions
 
-   """
-   arr=arr
-   mean=mean
-   sigma=sigma
-   scale=scale
-   dim=np.ndim(arr)-1
+       arr--The input array of N dimensions
+       mean--the mean of the distribution--either a scalor or N-dimensional array
+       sigma--the std deviation of the distribution--either a scalor or N-dimensial array
+       scale--the scale of the distrubion
 
-   #check to make sure that mean and sigma have dimensions that match dim
-   #and create the arrays to calculate the distribution
-   if isinstance(mean, np.ndarray):
-       if len(mean)!=dim:
-           raise FunctionsError('Mean and input array are different number of dimensions')
-       mean=np.reshape(mean, (dim,1,1))
-   if isinstance(sigma, np.ndarray):
-       if len(sigma)!=dim:
-           raise FunctionsError('Sigma and input array are different number of dimensions')
-       sigma=np.reshape(sigma, (dim,1,1))
+    """
+    arr = arr
+    mean = mean
+    sigma = sigma
+    scale = scale
+    dim = np.ndim(arr) - 1
 
-   #calculate the gaussian
-   z=scale*np.exp(-0.5*(arr-mean)**2/sigma)
-   return z
-      
+    # check to make sure that mean and sigma have dimensions that match dim
+    # and create the arrays to calculate the distribution
+    if isinstance(mean, np.ndarray):
+        if len(mean) != dim:
+            raise FunctionsError('Mean and input array are different number of dimensions')
+        mean = np.reshape(mean, (dim, 1, 1))
+    if isinstance(sigma, np.ndarray):
+        if len(sigma) != dim:
+            raise FunctionsError('Sigma and input array are different number of dimensions')
+        sigma = np.reshape(sigma, (dim, 1, 1))
+
+    # calculate the gaussian
+    z = scale * np.exp(-0.5 * (arr - mean) ** 2 / sigma)
+    return z
+
 
 def sersic(arr, deg, r_e, ell=1, scale=1):
-   """Produce a light distribution given by a sersic profile
-       I=I_e exp(-b [ (R/R_E)^(1/n)-1])
-    
-       where:
-       Gamma(2n)=gamma(2n, b)
-   """
+    """Produce a light distribution given by a sersic profile
+        I=I_e exp(-b [ (R/R_E)^(1/n)-1])
 
-   dim=np.ndim(arr)-1
-   #assume radial symmetry
-   if dim==0:
-      r=abs(arr/r_e)
-   else:
-      pass 
+        where:
+        Gamma(2n)=gamma(2n, b)
+    """
 
-   z=scale*exp(-b*(r**(1/deg)-1))
-   return z
+    dim = np.ndim(arr) - 1
+    # assume radial symmetry
+    if dim == 0:
+        r = abs(arr / r_e)
+    else:
+        pass
 
-      
+    z = scale * exp(-b * (r ** (1 / deg) - 1))
+    return z

--- a/PySpectrograph/Utilities/__init__.py
+++ b/PySpectrograph/Utilities/__init__.py
@@ -1,4 +1,4 @@
-"""Utilities is part of The PySpectrograph package  and holds general tasks 
+"""Utilities is part of The PySpectrograph package  and holds general tasks
 that are useful in the reduction and analysis of spectroscopic data
 
  * degremath--trigometric functions for arrays and scalars in degrees
@@ -8,6 +8,6 @@ that are useful in the reduction and analysis of spectroscopic data
 
 """
 
-import degreemath
-import fit
-import Functions
+from . import degreemath
+from . import fit
+from . import Functions

--- a/PySpectrograph/Utilities/degreemath.py
+++ b/PySpectrograph/Utilities/degreemath.py
@@ -1,21 +1,23 @@
 import math
 import numpy
 
+
 def sind(x):
-   """Return the sin of x where x is in degrees"""
-   if isinstance(x, numpy.ndarray):
-      return numpy.sin(math.pi*x/180.0)
-   return math.sin(math.radians(x))
+    """Return the sin of x where x is in degrees"""
+    if isinstance(x, numpy.ndarray):
+        return numpy.sin(math.pi * x / 180.0)
+    return math.sin(math.radians(x))
 
 
 def cosd(x):
-   """Return the cos of x where x is in degrees"""
-   if isinstance(x, numpy.ndarray):
-      return numpy.cos(math.pi*x/180.0)
-   return math.cos(math.radians(x))
+    """Return the cos of x where x is in degrees"""
+    if isinstance(x, numpy.ndarray):
+        return numpy.cos(math.pi * x / 180.0)
+    return math.cos(math.radians(x))
+
 
 def tand(x):
-   """Return the cos of x where x is in degrees"""
-   if isinstance(x, numpy.ndarray):
-      return numpy.tan(math.pi*x/180.0)
-   return math.cos(math.radians(x))
+    """Return the cos of x where x is in degrees"""
+    if isinstance(x, numpy.ndarray):
+        return numpy.tan(math.pi * x / 180.0)
+    return math.cos(math.radians(x))

--- a/PySpectrograph/Utilities/fit.py
+++ b/PySpectrograph/Utilities/fit.py
@@ -7,213 +7,226 @@ cookbook.
 
 """
 
-import numpy as np 
+import numpy as np
 from scipy import optimize, interpolate
 from scipy.special import legendre, chebyt
 
+
 class power:
-   """A class to produce a polynomial term of power n.  
 
-      This has similar behavior to scipy.special.legendre
+    """A class to produce a polynomial term of power n.
 
-   """
-   def __init__(self, n):
-       self.n=n
+       This has similar behavior to scipy.special.legendre
 
-   def __call__(self, x):
-       return x**self.n
+    """
 
+    def __init__(self, n):
+        self.n = n
+
+    def __call__(self, x):
+        return x ** self.n
 
 
 class Parameter:
+
     def __init__(self, value):
-            self.value = value
+        self.value = value
 
     def set(self, value):
-            self.value = value
+        self.value = value
 
     def __call__(self):
-            return self.value
+        return self.value
 
-def fit(function, parameters, y, x = None, var=1, warn=False):
+
+def fit(function, parameters, y, x=None, var=1, warn=False):
     def f(params):
         i = 0
         for p in parameters:
             p.set(params[i])
             i += 1
-        return (y - function(x))/var
+        return (y - function(x)) / var
 
-    if x is None: x = np.arange(y.shape[0])
+    if x is None:
+        x = np.arange(y.shape[0])
     p = [param() for param in parameters]
     return optimize.leastsq(f, p, full_output=1, warning=warn)
-    
-
-class curfit: 
-   """Given an x and y data arrays,  find the best fitting curve
- 
-   * x - list or array of x data
-   * y - list or array of y data
-   * yerr - error on y data
-   * coef - Initial coefficients for fit
-   * function - function to be fit to the data:
-                options include polynomial, legendre, chebyshev, or spline
-   * order - order of the function that is fit
 
 
-   """
-   def __init__(self, x, y, yerr=None, coef=None, function='poly', order=3):
+class curfit:
 
-       #set up the variables
-       self.x=x
-       self.y=y
-       if yerr is None:
-           self.yerr=1
-       else:
-           self.yerr=yerr
-       self.order=order
+    """Given an x and y data arrays,  find the best fitting curve
 
-       self.set_func(function)
-       self.set_coef(coef)
+    * x - list or array of x data
+    * y - list or array of y data
+    * yerr - error on y data
+    * coef - Initial coefficients for fit
+    * function - function to be fit to the data:
+                 options include polynomial, legendre, chebyshev, or spline
+    * order - order of the function that is fit
 
 
-   def set_coef(self, coef=None):
-       """Set the coefficients for the fits for poly, legendre, and chebyshev"""
-       if coef is None: coef=np.ones(self.order+1)
-       if isinstance(coef, np.ndarray):
-           self.coef=coef
-       elif isinstance(coef, list):
-           self.coef=np.array(coef)
-       else:
-           self.coef=np.array([coef])
+    """
 
-   def set_func(self, function):
-       """Set the function that will be used. 
-       * function - name of function to be used
+    def __init__(self, x, y, yerr=None, coef=None, function='poly', order=3):
 
-       It will throw an error if an inappropriate function is given
-       """
-       self.function=function
-       if self.function=='poly' or self.function=='polynomial' or self.function=='power':
-           self.func=power
-       elif self.function=='legendre':
-           self.func=legendre
-       elif self.function=='chebyshev':
-           self.func=chebyt
-       elif self.function=='spline':
-           self.func=None
-       else:
-           msg='%s is not a valid function' % self.function
-           raise Exception(msg)
+        # set up the variables
+        self.x = x
+        self.y = y
+        if yerr is None:
+            self.yerr = 1
+        else:
+            self.yerr = yerr
+        self.order = order
 
-   def set_weight(self, err):
-       """Set the weighting for spline fitting """
-       if isinstance(err, np.ndarray):
-          if err.any()!=0:
-             self.weight=1/err
-             return 
-       self.weight=None
+        self.set_func(function)
+        self.set_coef(coef)
 
-   def __call__(self, x):
-       """Return the value of the function evaluated at x"""
-       if self.function=='spline':
-           return interpolate.splev(x, self.coef, der=0)
-       v=x*0.0
-       for i in range(self.order+1):
-           v += self.coef[i]*self.func(i)(x)
-       return v
+    def set_coef(self, coef=None):
+        """Set the coefficients for the fits for poly, legendre, and chebyshev"""
+        if coef is None:
+            coef = np.ones(self.order + 1)
+        if isinstance(coef, np.ndarray):
+            self.coef = coef
+        elif isinstance(coef, list):
+            self.coef = np.array(coef)
+        else:
+            self.coef = np.array([coef])
 
-   def erf(self, coef, x, y, v):
-       """Error function to be minimized in least-squares fit"""
-       self.set_coef(coef)
-       return (y-self.__call__(x))/v
+    def set_func(self, function):
+        """Set the function that will be used.
+        * function - name of function to be used
 
-   def sigma(self, x, y):
-       """Return the RMS of the fit """
-       return (((y-self(x))**2).mean())**0.5
+        It will throw an error if an inappropriate function is given
+        """
+        self.function = function
+        if self.function == 'poly' or self.function == 'polynomial' or self.function == 'power':
+            self.func = power
+        elif self.function == 'legendre':
+            self.func = legendre
+        elif self.function == 'chebyshev':
+            self.func = chebyt
+        elif self.function == 'spline':
+            self.func = None
+        else:
+            msg = '%s is not a valid function' % self.function
+            raise Exception(msg)
 
-   def chisq(self, x, y, err):
-       """Return the chi^2 of the fit"""
-       return (((y-self(x))/err)**2).sum()
+    def set_weight(self, err):
+        """Set the weighting for spline fitting """
+        if isinstance(err, np.ndarray):
+            if err.any() != 0:
+                self.weight = 1 / err
+                return
+        self.weight = None
 
-   def fit(self, task=0, s=None, t=None, full_output=1, warn=False):
-       """Fit the function to the data"""
-       if self.function=='spline':
-          self.set_weight(self.yerr)
-          self.results=interpolate.splrep(self.x, self.y, w=self.weight,  task=0, s=None, t=None, k=self.order, full_output=
-full_output)
-          #w=None, k=self.order, s=s, t=t, task=task, 
-          # full_output=full_output)
-          self.set_coef(self.results[0])
-               
-       else:
-           self.results=optimize.leastsq(self.erf, self.coef,
-               args=(self.x, self.y, self.yerr), 
-               full_output=full_output)
-           self.set_coef(self.results[0])
+    def __call__(self, x):
+        """Return the value of the function evaluated at x"""
+        if self.function == 'spline':
+            return interpolate.splev(x, self.coef, der=0)
+        v = x * 0.0
+        for i in range(self.order + 1):
+            v += self.coef[i] * self.func(i)(x)
+        return v
+
+    def erf(self, coef, x, y, v):
+        """Error function to be minimized in least-squares fit"""
+        self.set_coef(coef)
+        return (y - self.__call__(x)) / v
+
+    def sigma(self, x, y):
+        """Return the RMS of the fit """
+        return (((y - self(x)) ** 2).mean()) ** 0.5
+
+    def chisq(self, x, y, err):
+        """Return the chi^2 of the fit"""
+        return (((y - self(x)) / err) ** 2).sum()
+
+    def fit(self, task=0, s=None, t=None, full_output=1, warn=False):
+        """Fit the function to the data"""
+        if self.function == 'spline':
+            self.set_weight(self.yerr)
+            self.results = interpolate.splrep(
+                self.x,
+                self.y,
+                w=self.weight,
+                task=0,
+                s=None,
+                t=None,
+                k=self.order,
+                full_output=full_output)
+            # w=None, k=self.order, s=s, t=t, task=task,
+            # full_output=full_output)
+            self.set_coef(self.results[0])
+
+        else:
+            self.results = optimize.leastsq(self.erf, self.coef,
+                                            args=(self.x, self.y, self.yerr),
+                                            full_output=full_output)
+            self.set_coef(self.results[0])
+
 
 class interfit(curfit):
-   """Given an x and y data arrays,  find the best fitting curve.  
-       After the initial fit, iterate on the solution to reject any 
-       points which are away from the solution 
- 
-   * x - list or array of x data
-   * y - list or array of y data
-   * yerr - error on y data
-   * coef - Initial coefficients for fit
-   * function - function to be fit to the data:
-                options include polynomial, legendre, chebyshev, or spline
-   * order - order of the function that is fit
-   * thresh - threshold for rejection
-   * niter - number of times to iterate
+
+    """Given an x and y data arrays,  find the best fitting curve.
+        After the initial fit, iterate on the solution to reject any
+        points which are away from the solution
+
+    * x - list or array of x data
+    * y - list or array of y data
+    * yerr - error on y data
+    * coef - Initial coefficients for fit
+    * function - function to be fit to the data:
+                 options include polynomial, legendre, chebyshev, or spline
+    * order - order of the function that is fit
+    * thresh - threshold for rejection
+    * niter - number of times to iterate
 
 
-   """
-   def __init__(self, x, y, yerr=None, coef=None, function='poly', order=3, 
-                thresh=3, niter=5):
-       #set up the variables
-       self.x_orig=x
-       self.y_orig=y
-       self.npts=len(self.x_orig)
-       if yerr is None:
-           self.yerr_orig=np.ones(self.npts)
-       else:
-           self.yerr_orig=yerr
+    """
 
-       self.order=order
-       self.thresh=thresh
-       self.niter=niter
+    def __init__(self, x, y, yerr=None, coef=None, function='poly', order=3,
+                 thresh=3, niter=5):
+        # set up the variables
+        self.x_orig = x
+        self.y_orig = y
+        self.npts = len(self.x_orig)
+        if yerr is None:
+            self.yerr_orig = np.ones(self.npts)
+        else:
+            self.yerr_orig = yerr
 
-       self.set_func(function)
-       self.set_coef(coef)
-       self.set_mask(init=True)
-       self.set_arrays(self.x_orig, self.y_orig, self.mask, err=self.yerr_orig)
+        self.order = order
+        self.thresh = thresh
+        self.niter = niter
 
-   def set_mask(self, init=False):
-       """Set the mask according to the values for rejecting points"""
-       self.mask=np.ones(self.npts, dtype=bool)
-       if init: return
+        self.set_func(function)
+        self.set_coef(coef)
+        self.set_mask(init=True)
+        self.set_arrays(self.x_orig, self.y_orig, self.mask, err=self.yerr_orig)
 
-       #difference the arrays
-       diff=self.y_orig-self(self.x_orig)
-       sigma=self.sigma(self.x, self.y)
-       self.mask=(abs(diff)<self.thresh*sigma)
-       
+    def set_mask(self, init=False):
+        """Set the mask according to the values for rejecting points"""
+        self.mask = np.ones(self.npts, dtype=bool)
+        if init:
+            return
 
-   def set_arrays(self, x, y, mask, err=None):
-       """set the arrays using a mask"""
-       self.x=x[mask]
-       self.y=y[mask]
-       if err is not None:
-          self.yerr=err[mask]
- 
+        # difference the arrays
+        diff = self.y_orig - self(self.x_orig)
+        sigma = self.sigma(self.x, self.y)
+        self.mask = (abs(diff) < self.thresh * sigma)
 
-   def interfit(self):
-       """Fit a function and then iterate it to reject possible outlyiers"""
-       self.fit()
-       for i in range(self.niter):
-           self.set_mask()
-           self.set_arrays(self.x_orig, self.y_orig, self.mask, err=self.yerr_orig)
-           self.fit()
+    def set_arrays(self, x, y, mask, err=None):
+        """set the arrays using a mask"""
+        self.x = x[mask]
+        self.y = y[mask]
+        if err is not None:
+            self.yerr = err[mask]
 
-
-
+    def interfit(self):
+        """Fit a function and then iterate it to reject possible outlyiers"""
+        self.fit()
+        for i in range(self.niter):
+            self.set_mask()
+            self.set_arrays(self.x_orig, self.y_orig, self.mask, err=self.yerr_orig)
+            self.fit()

--- a/PySpectrograph/Utilities/makeplots.py
+++ b/PySpectrograph/Utilities/makeplots.py
@@ -7,62 +7,65 @@
 from pylab import *
 import numpy
 
+
 def plotframe(data):
-   """Plot the entire data array 
-      returns a figure
-   """
-   nimg=10
-   ywidth=0.08
-   xlen=len(data[0])/nimg
-   for i in range(nimg):
-      yax=0.90-ywidth*1.1*i
-      x1=xlen*i
-      x2=xlen*(1+i)
-      f=axes([0.1,yax,0.8,ywidth])
-      f.imshow(data[:,x1:x2], cmap=cm.gray, aspect='auto', vmin=-5, vmax=50 )
-      f.axis('off')
-   return f
+    """Plot the entire data array
+       returns a figure
+    """
+    nimg = 10
+    ywidth = 0.08
+    xlen = len(data[0]) / nimg
+    for i in range(nimg):
+        yax = 0.90 - ywidth * 1.1 * i
+        x1 = xlen * i
+        x2 = xlen * (1 + i)
+        f = axes([0.1, yax, 0.8, ywidth])
+        f.imshow(data[:, x1:x2], cmap=cm.gray, aspect='auto', vmin=-5, vmax=50)
+        f.axis('off')
+    return f
+
 
 def plotfeature(f, wave, data, w1, w2, z):
     """Plot a section of the data array
        as indicated by w1 and w2
     """
-    w1=w1*(1+z)
-    w2=w2*(1+z)
-    if w1>wave.max(): return  f
-    mask=(w1 < wave)*(wave < w2)
-    mdata=data[:,mask]
-    f.imshow(mdata, cmap=cm.gray, aspect='auto', vmin=-5, vmax=50  )
-    #set up the axis labels
-    x1=wave[mask][0]
-    x2=wave[mask][-1]
-    dw=(x2-x1)/5
-    xtarr=arange(x1,x2+dw,dw)
-    xtlab=[]
+    w1 = w1 * (1 + z)
+    w2 = w2 * (1 + z)
+    if w1 > wave.max():
+        return f
+    mask = (w1 < wave) * (wave < w2)
+    mdata = data[:, mask]
+    f.imshow(mdata, cmap=cm.gray, aspect='auto', vmin=-5, vmax=50)
+    # set up the axis labels
+    x1 = wave[mask][0]
+    x2 = wave[mask][-1]
+    dw = (x2 - x1) / 5
+    xtarr = arange(x1, x2 + dw, dw)
+    xtlab = []
     for x in xticks()[0]:
-	if x >= 0 and x < len(wave[mask]):
-          x=wave[mask][x]
-	  xtlab.append('%4.2f'%x)
-	else:
-	  xtlab.append('0')
+        if x >= 0 and x < len(wave[mask]):
+            x = wave[mask][x]
+            xtlab.append('%4.2f' % x)
+        else:
+            xtlab.append('0')
     f.set_yticklabels([])
     f.set_xticklabels([])
     return f
 
-def plotlinefeature(f, wave, flux, w1, w2,z):
-    w1=w1*(1+z)
-    w2=w2*(1+z)
-    mask=(w1 < wave)*(wave < w2)
-    f=plotline(f,wave[mask],flux[mask])
+
+def plotlinefeature(f, wave, flux, w1, w2, z):
+    w1 = w1 * (1 + z)
+    w2 = w2 * (1 + z)
+    mask = (w1 < wave) * (wave < w2)
+    f = plotline(f, wave[mask], flux[mask])
     return f
 
-def plotline(f,wave, flux, color=None):
+
+def plotline(f, wave, flux, color=None):
     if color:
-      f.plot(wave,flux,ls='-',  color=color, lw=1.55)
+        f.plot(wave, flux, ls='-', color=color, lw=1.55)
     else:
-      f.plot(wave,flux,ls='-',  lw=1.55)
-    f.set_xlim((wave[0],wave[-1]))
-    #f.set_yticklabels([])
+        f.plot(wave, flux, ls='-', lw=1.55)
+    f.set_xlim((wave[0], wave[-1]))
+    # f.set_yticklabels([])
     return f
-
-

--- a/PySpectrograph/WavelengthSolution/ImageSolution.py
+++ b/PySpectrograph/WavelengthSolution/ImageSolution.py
@@ -1,9 +1,9 @@
-"""ImageSolution is a task describing the functional form for fitting an 
-spectrograph model to an 2-D spectroscopic data.  The model will output 
+"""ImageSolution is a task describing the functional form for fitting an
+spectrograph model to an 2-D spectroscopic data.  The model will output
 the best fit spectrograph to the observed data
 
-In the Spectrograph model, the three things that we can alter are the 
-x position, the y position, and focus.    
+In the Spectrograph model, the three things that we can alter are the
+x position, the y position, and focus.
 
 HISTORY
 20100614  SMC Initially Written by SM Crawford
@@ -21,105 +21,112 @@ from CreateImage import CreateImage
 
 import pylab as pl
 
+
 class fitimage:
-   """Fit legendre polynomials to a function"""
-   def __init__(self, order=3):
-       self.order=order
-       self.setcoef()
 
-   def setcoef(self, x=1):
-       self.coef=[]
-       for i in range(self.order):
-           try:
-               self.coef.append(ft.Parameter(x[i]))
-           except TypeError:
-               self.coef.append(ft.Parameter(x))
-   
-   def legendre(self, x):
-       v=0
-       for i in range(self.order):
-           v +=self.coef[i]()*legendre(i)(x)
-       return v
+    """Fit legendre polynomials to a function"""
 
-   def fit(self, data, x=None, var=None):
-       return ft.fit(self.legendre, self.coef, data, x=x, var=var)
+    def __init__(self, order=3):
+        self.order = order
+        self.setcoef()
+
+    def setcoef(self, x=1):
+        self.coef = []
+        for i in range(self.order):
+            try:
+                self.coef.append(ft.Parameter(x[i]))
+            except TypeError:
+                self.coef.append(ft.Parameter(x))
+
+    def legendre(self, x):
+        v = 0
+        for i in range(self.order):
+            v += self.coef[i]() * legendre(i)(x)
+        return v
+
+    def fit(self, data, x=None, var=None):
+        return ft.fit(self.legendre, self.coef, data, x=x, var=var)
+
 
 class ImageSolution:
-   """ImageSolution is a task describing the functional form for transforming 
-      pixel position to wavelength for a 2-D image using a model for a 
-      spectrograph. 
 
-      data--2-D array to be fit
-   """
+    """ImageSolution is a task describing the functional form for transforming
+       pixel position to wavelength for a 2-D image using a model for a
+       spectrograph.
 
+       data--2-D array to be fit
+    """
 
-   def __init__(self,data, sgraph, spectrum):
-  
-       #set up the variables
-       self.data=data
-       self.sgraph=sgraph
-       self.spectrum=spectrum
+    def __init__(self, data, sgraph, spectrum):
 
-       #set up the sizes
-       self.ylen=len(self.data)
-       self.xlen=len(self.data[0])
+        # set up the variables
+        self.data = data
+        self.sgraph = sgraph
+        self.spectrum = spectrum
 
-       #set the parameters
-       self.xpos=ft.Parameter(self.sgraph.detector.xpos)
-       self.ypos=ft.Parameter(self.sgraph.detector.ypos)
-       self.fcam=ft.Parameter(self.sgraph.camera.focallength)
-       self.nd0=ft.Parameter(1)
-       self.nd1=ft.Parameter(0.00)
-       self.nd2=ft.Parameter(0.00)
-       #self.xpos=ft.Parameter(2*0.015*8.169)
-       #self.fcam=ft.Parameter(327.85)
-       #self.coef=[self.xpos, self.ypos, self.fcam] 
-       self.coef=[self.nd0, self.nd1, self.nd2]
-       #print self.sgraph.gratingequation
-         
-       j=int(self.ylen/2)
-       xarr=np.arange(self.xlen)
-       yarr=np.arange(self.ylen)
-       self.data1=self.data[j,:]
-       self.err1=abs(self.data1)+self.data1.mean()
-       #print self.makewave(500)
-       #print self.xpos(), self.ypos(), self.fcam(), self.nd0()
-       #print self.nd0(), self.nd1(), self.nd2()
-       #print (self.data1-self.makeflux(xarr)).sum()
-       self.fit( self.makeflux, self.coef, self.data1, var=self.err1)
+        # set up the sizes
+        self.ylen = len(self.data)
+        self.xlen = len(self.data[0])
 
-       warr=self.makewave(xarr)
-       #print self.makewave(500)
-       #print self.xpos(), self.ypos(), self.fcam() 
-       #print self.nd0(), self.nd1(), self.nd2()
-       #print (self.data1-self.makeflux(xarr)).sum()
+        # set the parameters
+        self.xpos = ft.Parameter(self.sgraph.detector.xpos)
+        self.ypos = ft.Parameter(self.sgraph.detector.ypos)
+        self.fcam = ft.Parameter(self.sgraph.camera.focallength)
+        self.nd0 = ft.Parameter(1)
+        self.nd1 = ft.Parameter(0.00)
+        self.nd2 = ft.Parameter(0.00)
+        # self.xpos=ft.Parameter(2*0.015*8.169)
+        # self.fcam=ft.Parameter(327.85)
+        #self.coef=[self.xpos, self.ypos, self.fcam]
+        self.coef = [self.nd0, self.nd1, self.nd2]
+        # print self.sgraph.gratingequation
 
-       #check the results
-       pl.figure()
-       pl.plot(self.spectrum.wavelength, self.spectrum.flux*self.data.max()/self.spectrum.flux.max())
-       pl.plot(warr, self.data[j,:])
-       pl.show()
+        j = int(self.ylen / 2)
+        xarr = np.arange(self.xlen)
+        yarr = np.arange(self.ylen)
+        self.data1 = self.data[j, :]
+        self.err1 = abs(self.data1) + self.data1.mean()
+        # print self.makewave(500)
+        # print self.xpos(), self.ypos(), self.fcam(), self.nd0()
+        # print self.nd0(), self.nd1(), self.nd2()
+        #print (self.data1-self.makeflux(xarr)).sum()
+        self.fit(self.makeflux, self.coef, self.data1, var=self.err1)
 
-   def makend(self, x):
-       return self.nd0()+self.nd1()*x+self.nd2()*x**2
+        warr = self.makewave(xarr)
+        # print self.makewave(500)
+        # print self.xpos(), self.ypos(), self.fcam()
+        # print self.nd0(), self.nd1(), self.nd2()
+        #print (self.data1-self.makeflux(xarr)).sum()
 
+        # check the results
+        pl.figure()
+        pl.plot(self.spectrum.wavelength, self.spectrum.flux * self.data.max() / self.spectrum.flux.max())
+        pl.plot(warr, self.data[j, :])
+        pl.show()
 
-   def makewave(self, x):
-       dx=self.xpos()
-       dy=self.ypos()
-       alpha=self.sgraph.gratang
-       beta=self.sgraph.gratang-self.sgraph.camang
-       dw=0.5*1e7*self.sgraph.calc_resolelement(alpha, beta)
-       #dx=self.sgraph.detector.xpos/(self.sgraph.detector.xbin*self.sgraph.detector.pix_scale)
-       #dy=self.sgraph.detector.ypos/(self.sgraph.detector.ybin*self.sgraph.detector.pix_scale)
-       dbeta=np.degrees(np.arctan(self.sgraph.detector.xbin*self.sgraph.detector.pix_size*(x-0.5*self.xlen+dx)/self.fcam()))
-       gamma=np.degrees(np.arctan(self.sgraph.detector.ybin*self.sgraph.detector.pix_size*(dy)/self.fcam()))
-       return 1e7*self.sgraph.calc_wavelength(alpha, beta-dbeta, gamma=gamma) * self.makend(x)
- 
+    def makend(self, x):
+        return self.nd0() + self.nd1() * x + self.nd2() * x ** 2
 
+    def makewave(self, x):
+        dx = self.xpos()
+        dy = self.ypos()
+        alpha = self.sgraph.gratang
+        beta = self.sgraph.gratang - self.sgraph.camang
+        dw = 0.5 * 1e7 * self.sgraph.calc_resolelement(alpha, beta)
+        # dx=self.sgraph.detector.xpos/(self.sgraph.detector.xbin*self.sgraph.detector.pix_scale)
+        # dy=self.sgraph.detector.ypos/(self.sgraph.detector.ybin*self.sgraph.detector.pix_scale)
+        dbeta = np.degrees(np.arctan(self.sgraph.detector.xbin *
+                                     self.sgraph.detector.pix_size *
+                                     (x -
+                                      0.5 *
+                                      self.xlen +
+                                      dx) /
+                                     self.fcam()))
+        gamma = np.degrees(np.arctan(self.sgraph.detector.ybin * self.sgraph.detector.pix_size * (dy) / self.fcam()))
+        return 1e7 * self.sgraph.calc_wavelength(alpha, beta - dbeta, gamma=gamma) * self.makend(x)
 
-   def makeflux(self, x):
-       return self.data.max()/self.spectrum.flux.max() * self.spectrum.get_flux(self.makewave(x))
+    def makeflux(self, x):
+        return self.data.max() / self.spectrum.flux.max() * self.spectrum.get_flux(self.makewave(x))
 
-   def fit(self, func, coef, data, var):
-       return ft.fit(func, coef, data, var=var)
+    def fit(self, func, coef, data, var):
+        return ft.fit(func, coef, data, var=var)

--- a/PySpectrograph/WavelengthSolution/LineFit.py
+++ b/PySpectrograph/WavelengthSolution/LineFit.py
@@ -1,8 +1,8 @@
-"""LineFit is a task describing the functional form for transforming 
-pixel position to wavelength by fitting a model spectrum.  The inputs for this task 
+"""LineFit is a task describing the functional form for transforming
+pixel position to wavelength by fitting a model spectrum.  The inputs for this task
 are an observed spectrum and a calibrated spectrum
-and the corresponding wavelength.  The user selects an input functional form and 
-order for that form.  The task then calculates the coefficients for that form.  
+and the corresponding wavelength.  The user selects an input functional form and
+order for that form.  The task then calculates the coefficients for that form.
 Possible options for the wavelength solution include polynomial, legendre, spline.
 
 HISTORY
@@ -20,48 +20,47 @@ from scipy import optimize, interpolate
 
 from PySpectrograph.Utilities.fit import fit, interfit
 
+
 class LineFit(interfit):
-   """LineSolution is a task describing the functional form for transforming 
-      pixel position to wavelength. 
 
-   * obsspec --observed spectrum 
-   * calspec --calibrated spectrum
-   * function - function to be fit to the data:
-                options include polynomial, legendre, chebyshev, or spline
-   * order - order of the function that is fit
+    """LineSolution is a task describing the functional form for transforming
+       pixel position to wavelength.
 
-   """
+    * obsspec --observed spectrum
+    * calspec --calibrated spectrum
+    * function - function to be fit to the data:
+                 options include polynomial, legendre, chebyshev, or spline
+    * order - order of the function that is fit
 
-   def __init__(self, obsspec, calspec, function='poly', order=3, coef=None):
+    """
 
-       #set up the spectrum
-       self.obs_spec=obsspec
-       self.cal_spec=calspec
+    def __init__(self, obsspec, calspec, function='poly', order=3, coef=None):
 
-       #set up the function
-       self.order=order
-       self.set_func(function)
+        # set up the spectrum
+        self.obs_spec = obsspec
+        self.cal_spec = calspec
 
-       #set up the coef
-       self.set_coef(coef)
+        # set up the function
+        self.order = order
+        self.set_func(function)
 
- 
-   def flux(self, x):
-       """Return the calibrated flux at the transformed position x"""
-       return self.cal_spec.get_flux(self(x))
+        # set up the coef
+        self.set_coef(coef)
 
-   def value(self, x):
-       """Calculate the value of the array
-       """
-       return self(x)
+    def flux(self, x):
+        """Return the calibrated flux at the transformed position x"""
+        return self.cal_spec.get_flux(self(x))
 
-   def errfit(self, coef, x, y, err=1):
-       self.set_coe(coef)
-       return (y-self.flux(x))
+    def value(self, x):
+        """Calculate the value of the array
+        """
+        return self(x)
 
-   def lfit(self, task=0, s=None, t=None, full_output=1, warn=False):
-        self.results=optimize.leastsq(self.errfit, self.coef,
-               args=(self.obs_spec.wavelength, self.obs_spec.flux), full_output=full_output)
+    def errfit(self, coef, x, y, err=1):
+        self.set_coe(coef)
+        return (y - self.flux(x))
+
+    def lfit(self, task=0, s=None, t=None, full_output=1, warn=False):
+        self.results = optimize.leastsq(self.errfit, self.coef,
+                                        args=(self.obs_spec.wavelength, self.obs_spec.flux), full_output=full_output)
         self.set_coef(self.results[0])
-
-

--- a/PySpectrograph/WavelengthSolution/LineSolution.py
+++ b/PySpectrograph/WavelengthSolution/LineSolution.py
@@ -1,7 +1,7 @@
-"""LineSolution is a task describing the functional form for transforming 
+"""LineSolution is a task describing the functional form for transforming
 pixel position to wavelength.  The inputs for this task are the given pixel position
-and the corresponding wavelength.  The user selects an input functional form and 
-order for that form.  The task then calculates the coefficients for that form.  
+and the corresponding wavelength.  The user selects an input functional form and
+order for that form.  The task then calculates the coefficients for that form.
 Possible options for the wavelength solution include polynomial, legendre, spline.
 
 HISTORY
@@ -17,26 +17,24 @@ import numpy as np
 from PySpectrograph.Utilities.fit import interfit
 
 
-
-
 class LineSolution(interfit):
-   """LineSolution is a task describing the functional form for transforming 
-      pixel position to wavelength. 
 
-   * x - list or array of x data
-   * y - list or array of y data
-   * yerr - error on y data
-   * coef - Initial coefficients for fit
-   * function - function to be fit to the data:
-                options include polynomial, legendre, chebyshev, or spline
-   * order - order of the function that is fit
-   * thresh - threshold for rejection
-   * niter - number of times to iterate
+    """LineSolution is a task describing the functional form for transforming
+       pixel position to wavelength.
 
-   """
+    * x - list or array of x data
+    * y - list or array of y data
+    * yerr - error on y data
+    * coef - Initial coefficients for fit
+    * function - function to be fit to the data:
+                 options include polynomial, legendre, chebyshev, or spline
+    * order - order of the function that is fit
+    * thresh - threshold for rejection
+    * niter - number of times to iterate
 
-   def value(self, x):
-       """Calculate the value of the array
-       """
-       return self(x)
+    """
 
+    def value(self, x):
+        """Calculate the value of the array
+        """
+        return self(x)

--- a/PySpectrograph/WavelengthSolution/ModelSolution.py
+++ b/PySpectrograph/WavelengthSolution/ModelSolution.py
@@ -1,9 +1,9 @@
-"""ModelSolution is a task describing the functional form for fitting an 
-spectrograph model to an 1-D spectroscopic data.  The model will output 
+"""ModelSolution is a task describing the functional form for fitting an
+spectrograph model to an 1-D spectroscopic data.  The model will output
 the best fit spectrograph to the observed data
 
-In the Spectrograph model, the three things that we can alter are the 
-x position, the y position, and focus.    
+In the Spectrograph model, the three things that we can alter are the
+x position, the y position, and focus.
 
 HISTORY
 20100614  SMC Initially Written by SM Crawford
@@ -16,126 +16,121 @@ LIMITATIONSa
 import numpy as np
 from PySpectrograph.Utilities import fit as ft
 
+
 class ModelSolution:
-   """ModelSolution is a task describing the functional form for transforming 
-      pixel position to wavelength for a 2-D image using a model for a 
-      spectrograph. 
 
-      xarr--pixel position of the spectrum
-      farr--the flux values for the spectrum
-      sgraph--model of a spectrograph
-      spectrum--model spectrum
-      yval--offset on the ccd in the y-direction
-      var--array with the variance values
-   """
+    """ModelSolution is a task describing the functional form for transforming
+       pixel position to wavelength for a 2-D image using a model for a
+       spectrograph.
 
+       xarr--pixel position of the spectrum
+       farr--the flux values for the spectrum
+       sgraph--model of a spectrograph
+       spectrum--model spectrum
+       yval--offset on the ccd in the y-direction
+       var--array with the variance values
+    """
 
-   def __init__(self, x, y, sgraph, xlen=3162, yval=0, order=3):
-  
-       #set up the variables
-       self.x=x
-       self.y=y
-       self.sgraph=sgraph
-       self.yval=yval
-       self.xlen=xlen
-       self.order=order
-       self.function='model'
+    def __init__(self, x, y, sgraph, xlen=3162, yval=0, order=3):
 
+        # set up the variables
+        self.x = x
+        self.y = y
+        self.sgraph = sgraph
+        self.yval = yval
+        self.xlen = xlen
+        self.order = order
+        self.function = 'model'
 
-       #set the parameters
-       self.reset_coef()
+        # set the parameters
+        self.reset_coef()
 
-   def reset_coef(self):
-       xpos=self.sgraph.detector.xpos
-       ypos=self.yval+self.sgraph.detector.ypos
-       fcam=self.sgraph.camera.focallength
-       self.set_spcoef(fcam, xpos, ypos)
-       self.spcoef=[self.fcam, self.xpos, self.ypos]
-       self.set_ndcoef()
+    def reset_coef(self):
+        xpos = self.sgraph.detector.xpos
+        ypos = self.yval + self.sgraph.detector.ypos
+        fcam = self.sgraph.camera.focallength
+        self.set_spcoef(fcam, xpos, ypos)
+        self.spcoef = [self.fcam, self.xpos, self.ypos]
+        self.set_ndcoef()
 
-       #the total coefficient
-       self.set_coef()
+        # the total coefficient
+        self.set_coef()
 
+    def set_spcoef(self, fcam, xpos, ypos):
+        self.fcam = ft.Parameter(fcam)
+        self.xpos = ft.Parameter(xpos)
+        self.ypos = ft.Parameter(ypos)
+        self.spcoef = [self.fcam, self.xpos, self.ypos]
 
-   def set_spcoef(self, fcam, xpos, ypos):
-       self.fcam=ft.Parameter(fcam)
-       self.xpos=ft.Parameter(xpos)
-       self.ypos=ft.Parameter(ypos)
-       self.spcoef=[self.fcam, self.xpos, self.ypos]
+    def set_coef(self):
+        self.coef = self.spcoef + self.ndcoef
 
-   def set_coef(self):
-       self.coef=self.spcoef+self.ndcoef
-
-   def set_ndcoef(self, x=[1.00,0.00,0.00]):
-        self.ndcoef=[]
+    def set_ndcoef(self, x=[1.00, 0.00, 0.00]):
+        self.ndcoef = []
         for i in range(self.order):
-           try:
-               self.ndcoef.append(ft.Parameter(x[i]))
-           except:
-               self.ndcoef.append(ft.Parameter(0.0))
+            try:
+                self.ndcoef.append(ft.Parameter(x[i]))
+            except:
+                self.ndcoef.append(ft.Parameter(0.0))
 
-   def set_xarr(self, xarr):
-       self.xarr=xarr
-       if self.xarr is None:
-          npix=self.sgraph.detector.width/(self.sgraph.detector.pix_size*self.sgraph.detector.xbin)
-          self.xarr=np.arange(npix)
-          self.xlen=len(self.xarr)
-       else:
-          self.xlen=len(self.xarr)
+    def set_xarr(self, xarr):
+        self.xarr = xarr
+        if self.xarr is None:
+            npix = self.sgraph.detector.width / (self.sgraph.detector.pix_size * self.sgraph.detector.xbin)
+            self.xarr = np.arange(npix)
+            self.xlen = len(self.xarr)
+        else:
+            self.xlen = len(self.xarr)
 
+    def nd(self, x):
+        v = 0
+        for i in range(self.order):
+            v += self.ndcoef[i]() * x ** i
+        return v
 
-   def nd(self, x):
-       v=0
-       for i in range(self.order):
-           v +=self.ndcoef[i]()*x**i
-       return v
+    def value(self, x):
+        """Return the wavelength value at x due to the model and current values for the model"""
+        # these are just left here for the record
+        # dx=self.sgraph.detector.xpos/(self.sgraph.detector.xbin*self.sgraph.detector.pix_scale)
+        # dy=self.sgraph.detector.ypos/(self.sgraph.detector.ybin*self.sgraph.detector.pix_scale)
+        fcam = self.spcoef[0]()
+        dx = self.spcoef[1]()
+        dy = self.spcoef[2]()
+        alpha = self.sgraph.gratang
+        beta = self.sgraph.gratang - self.sgraph.camang
+        dw = 0.5 * 1e7 * self.sgraph.calc_resolelement(alpha, beta)
+        dbeta = np.degrees(
+            np.arctan(self.sgraph.detector.xbin * self.sgraph.detector.pix_size * (x - 0.5 * self.xlen + dx) / fcam))
+        gamma = np.degrees(np.arctan(self.sgraph.detector.ybin * self.sgraph.detector.pix_size * (dy) / fcam))
+        return 1e7 * self.sgraph.calc_wavelength(alpha, beta - dbeta, gamma=gamma) * self.nd(x)
 
-   def value(self, x):
-       """Return the wavelength value at x due to the model and current values for the model"""
-       #these are just left here for the record
-       #dx=self.sgraph.detector.xpos/(self.sgraph.detector.xbin*self.sgraph.detector.pix_scale)
-       #dy=self.sgraph.detector.ypos/(self.sgraph.detector.ybin*self.sgraph.detector.pix_scale)
-       fcam=self.spcoef[0]()
-       dx=self.spcoef[1]()
-       dy=self.spcoef[2]()
-       alpha=self.sgraph.gratang
-       beta=self.sgraph.gratang-self.sgraph.camang
-       dw=0.5*1e7*self.sgraph.calc_resolelement(alpha, beta)
-       dbeta=np.degrees(np.arctan(self.sgraph.detector.xbin*self.sgraph.detector.pix_size*(x-0.5*self.xlen+dx)/fcam))
-       gamma=np.degrees(np.arctan(self.sgraph.detector.ybin*self.sgraph.detector.pix_size*(dy)/fcam))
-       return 1e7*self.sgraph.calc_wavelength(alpha, beta-dbeta, gamma=gamma) * self.nd(x)
- 
-   def erf(self, x, y):
-       retrun (y-self.value(x))
+    def erf(self, x, y):
+        retrun(y - self.value(x))
 
-   def fit_coef(self,  coef):
-       self.result=ft.fit(self.value, coef, self.y, x=self.x)
+    def fit_coef(self, coef):
+        self.result = ft.fit(self.value, coef, self.y, x=self.x)
 
-   def fit(self, cfit='all'):
-       """Fit can be set to be several different possibilites:
+    def fit(self, cfit='all'):
+        """Fit can be set to be several different possibilites:
 
-          pscoef--only fit xpos, ypos, fcam
-          ndcoef--only fit the index of refraction
-          all--fit coef and then fit ndcoef
-          both--fit coef and ndcoef 
-       """
-       if cfit in ['pscoef', 'all']:
-          self.fit_coef(self.spcoef)
-       if cfit in ['ndcoef', 'all']:
-          self.fit_coef(self.ndcoef)
-       if cfit in ['both']:
-          self.fit_coef(self.coef)
-       #update the total coefficient
-       self.set_coef()
+           pscoef--only fit xpos, ypos, fcam
+           ndcoef--only fit the index of refraction
+           all--fit coef and then fit ndcoef
+           both--fit coef and ndcoef
+        """
+        if cfit in ['pscoef', 'all']:
+            self.fit_coef(self.spcoef)
+        if cfit in ['ndcoef', 'all']:
+            self.fit_coef(self.ndcoef)
+        if cfit in ['both']:
+            self.fit_coef(self.coef)
+        # update the total coefficient
+        self.set_coef()
 
+    def sigma(self, x, y):
+        """Return the RMS of the fit """
+        return (((y - self.value(x)) ** 2).mean()) ** 0.5
 
-   def sigma(self, x, y):
-       """Return the RMS of the fit """
-       return (((y-self.value(x))**2).mean())**0.5
-
-   def chisq(self, x, y, err):
-       """Return the chi^2 of the fit"""
-       return (((y-self.value(x))/err)**2).sum()
-
-
-
+    def chisq(self, x, y, err):
+        """Return the chi^2 of the fit"""
+        return (((y - self.value(x)) / err) ** 2).sum()

--- a/PySpectrograph/WavelengthSolution/WavelengthSolution.py
+++ b/PySpectrograph/WavelengthSolution/WavelengthSolution.py
@@ -1,7 +1,7 @@
-"""Wavelength Solution is a task describing the functional form for transforming 
+"""Wavelength Solution is a task describing the functional form for transforming
 pixel position to wavelength.  The inputs for this task are the given pixel position
-and the corresponding wavelength.  The user selects an input functional form and 
-order for that form.  The task then calculates the coefficients for that form.  
+and the corresponding wavelength.  The user selects an input functional form and
+order for that form.  The task then calculates the coefficients for that form.
 Possible options for the wavelength solution include polynomial, legendre, spline.
 
 HISTORY
@@ -15,84 +15,80 @@ LIMITATIONS
 import numpy as np
 
 
-from LineSolution import LineSolution
-from ModelSolution import ModelSolution
-
+from .LineSolution import LineSolution
+from .ModelSolution import ModelSolution
 
 
 class WavelengthSolution:
-   """Wavelength Solution is a task describing the functional form for transforming 
-      pixel position to wavelength. 
-   """
-   func_options=['poly', 'polynomial', 'spline', 'legendre', 'chebyshev', 'model']
 
+    """Wavelength Solution is a task describing the functional form for transforming
+       pixel position to wavelength.
+    """
+    func_options = ['poly', 'polynomial', 'spline', 'legendre', 'chebyshev', 'model']
 
-   def __init__(self, x, w, function='poly', order=3, niter=5, thresh=3, 
-                sgraph=None, cfit='both', xlen=3162, yval=0):
-       self.sgraph=sgraph
-       self.function=function
-       self.order=order
-       self.niter=niter
-       self.thresh=thresh
-       self.cfit=cfit
-       self.xlen=xlen
-       self.yval=yval
- 
-       self.set_array(x,w)
-       self.set_func()
+    def __init__(self, x, w, function='poly', order=3, niter=5, thresh=3,
+                 sgraph=None, cfit='both', xlen=3162, yval=0):
+        self.sgraph = sgraph
+        self.function = function
+        self.order = order
+        self.niter = niter
+        self.thresh = thresh
+        self.cfit = cfit
+        self.xlen = xlen
+        self.yval = yval
 
-   def set_array(self, x, w):
-       self.x_arr=x
-       self.w_arr=w
+        self.set_array(x, w)
+        self.set_func()
 
-   def set_thresh(self, thresh):
-       self.thresh=thresh
+    def set_array(self, x, w):
+        self.x_arr = x
+        self.w_arr = w
 
-   def set_niter(self, niter):
-       self.niter=niter  
+    def set_thresh(self, thresh):
+        self.thresh = thresh
 
-   def set_func(self):
-       if self.function in ['poly', 'polynomial', 'spline', 'legendre', 'chebyshev']:
-          self.func=LineSolution(self.x_arr, self.w_arr, function=self.function, 
-                    order=self.order, niter=self.niter, thresh=self.thresh)
-       if self.function=='model':
-          self.func=ModelSolution(self.x_arr, self.w_arr, sgraph=self.sgraph, 
-                    xlen=self.xlen, yval=self.yval, order=self.order)
+    def set_niter(self, niter):
+        self.niter = niter
 
-   def fit(self):
-       if self.function in ['poly', 'polynomial', 'spline', 'legendre', 'chebyshev']:
-          self.func.interfit()
-          self.coef=self.func.coef
-       if self.function in ['model']:
-          self.func.fit(cfit=self.cfit)
-          self.coef=np.array([c() for c in self.func.coef])
-       #self.set_coef(coef)
+    def set_func(self):
+        if self.function in ['poly', 'polynomial', 'spline', 'legendre', 'chebyshev']:
+            self.func = LineSolution(self.x_arr, self.w_arr, function=self.function,
+                                     order=self.order, niter=self.niter, thresh=self.thresh)
+        if self.function == 'model':
+            self.func = ModelSolution(self.x_arr, self.w_arr, sgraph=self.sgraph,
+                                      xlen=self.xlen, yval=self.yval, order=self.order)
 
-   def set_coef(self, coef):
-       if self.function in ['poly', 'polynomial', 'spline', 'legendre', 'chebyshev']:
-           self.func.coef=coef
-           self.coef=self.func.coef
-       if self.function in ['model']:
-           for i in range(len(self.func.coef)):
-               self.func.coef[i].set(coef[i])
-           self.coef=np.array([c() for c in self.func.coef])
+    def fit(self):
+        if self.function in ['poly', 'polynomial', 'spline', 'legendre', 'chebyshev']:
+            self.func.interfit()
+            self.coef = self.func.coef
+        if self.function in ['model']:
+            self.func.fit(cfit=self.cfit)
+            self.coef = np.array([c() for c in self.func.coef])
+        # self.set_coef(coef)
 
-   def value(self, x):
-       return self.func.value(x) 
+    def set_coef(self, coef):
+        if self.function in ['poly', 'polynomial', 'spline', 'legendre', 'chebyshev']:
+            self.func.coef = coef
+            self.coef = self.func.coef
+        if self.function in ['model']:
+            for i in range(len(self.func.coef)):
+                self.func.coef[i].set(coef[i])
+            self.coef = np.array([c() for c in self.func.coef])
 
-   def invvalue(self, w):
-       """Given a wavelength, return the pixel position
- 
-       """
-       return w
+    def value(self, x):
+        return self.func.value(x)
 
-   def sigma(self, x, y):
-       """Return the RMS of the fit """
-       return (((y-self.value(x))**2).mean())**0.5
+    def invvalue(self, w):
+        """Given a wavelength, return the pixel position
 
-   def chisq(self, x, y, err):
-       """Return the chi^2 of the fit"""
-       return (((y-self.value(x))/err)**2).sum()
+        """
+        return w
 
+    def sigma(self, x, y):
+        """Return the RMS of the fit """
+        return (((y - self.value(x)) ** 2).mean()) ** 0.5
 
-
+    def chisq(self, x, y, err):
+        """Return the chi^2 of the fit"""
+        return (((y - self.value(x)) / err) ** 2).sum()

--- a/PySpectrograph/WavelengthSolution/__init__.py
+++ b/PySpectrograph/WavelengthSolution/__init__.py
@@ -4,4 +4,4 @@ pixel position and wavelength in an observed 1- or 2-D spectrum
 
 """
 
-import WavelengthSolution
+from . import WavelengthSolution

--- a/PySpectrograph/__init__.py
+++ b/PySpectrograph/__init__.py
@@ -7,31 +7,33 @@ Spectrograph--The basic equations and components of a spectrograph
 Models--models for different spectrographs
 Spectra--classes for the handling of spectra
 WavelengthSolutions--Methods for calculating the wavelength solution
-Identify--Tasks to measure the wavelength solution 
+Identify--Tasks to measure the wavelength solution
 Utilities--General useful tasks
 
 """
+
+
 class SpectrographError(Exception):
-   """Exception Raised for Spectrograph errors"""
-   pass
+
+    """Exception Raised for Spectrograph errors"""
+    pass
+
 
 class PySpectrographError(Exception):
-   """Exception Raised for PySpectrograph errors"""
-   pass
 
-import Utilities
+    """Exception Raised for PySpectrograph errors"""
+    pass
+
+from . import Utilities
 #import Spectrograph
-from Spectrograph import *
-import Models
-import Spectra
-from Spectra import *
-import WavelengthSolution
+from .Spectrograph import *
+from . import Models
+from . import Spectra
+from .Spectra import *
+from . import WavelengthSolution
 #import Identify
 
-__all__=['Identify','Models','Spectra','Spectrograph','Utilities','WavelengthSolution']
-__version__=0.30
+__all__ = ['Identify', 'Models', 'Spectra', 'Spectrograph', 'Utilities', 'WavelengthSolution']
+__version__ = 0.30
 
-#general class for errors
-
-
-
+# general class for errors

--- a/PySpectrograph/unit_tests/ut_CreateImage.py
+++ b/PySpectrograph/unit_tests/ut_CreateImage.py
@@ -6,7 +6,7 @@ HISTORY
 Limitations:
 
 """
-import os 
+import os
 
 import math
 import pyfits
@@ -19,38 +19,48 @@ from PySpectrograph.Models import RSSModel
 
 from pylab import *
 
-inimg='fmbxpP200610180009.fits'
-infile='Xe.dat'
-outfile='out.fits'
+inimg = 'fmbxpP200610180009.fits'
+infile = 'Xe.dat'
+outfile = 'out.fits'
 
-def test_CreateImage():    
 
-   #read in the data
-   hdu=pyfits.open(inimg)
-   im_arr=hdu[1].data
-   hdu.close()
+def test_CreateImage():
 
-   #set up the spectrum
-   stype='line'
-   w,s=np.loadtxt('Xe.dat', usecols=(0,1),unpack=True)
-   spec=Spectrum(w, s, wrange=[4000, 5000], dw=0.1, stype='line')
+    # read in the data
+    hdu = pyfits.open(inimg)
+    im_arr = hdu[1].data
+    hdu.close()
 
-   #set up the spectrograph
-   dx=2*0.015*8.169
-   dy=2*0.015*0.101
-   #set up the spectrograph
-   #rssmodel=RSSModel.RSSModel(grating_name='PG0900', gratang=13.625, camang=27.25, slit=1.0, xbin=2, ybin=2, xpos=dx, ypos=dy)
-   rssmodel=RSSModel.RSSModel(grating_name='PG3000', gratang=43.625, camang=87.25, slit=2.0, xbin=2, ybin=2, xpos=dx, ypos=dy)
+    # set up the spectrum
+    stype = 'line'
+    w, s = np.loadtxt('Xe.dat', usecols=(0, 1), unpack=True)
+    spec = Spectrum(w, s, wrange=[4000, 5000], dw=0.1, stype='line')
 
-   rssmodel.set_camera(name='RSS', focallength=330.0)
-   rss=rssmodel.rss
+    # set up the spectrograph
+    dx = 2 * 0.015 * 8.169
+    dy = 2 * 0.015 * 0.101
+    # set up the spectrograph
+    #rssmodel=RSSModel.RSSModel(grating_name='PG0900', gratang=13.625, camang=27.25, slit=1.0, xbin=2, ybin=2, xpos=dx, ypos=dy)
+    rssmodel = RSSModel.RSSModel(
+        grating_name='PG3000',
+        gratang=43.625,
+        camang=87.25,
+        slit=2.0,
+        xbin=2,
+        ybin=2,
+        xpos=dx,
+        ypos=dy)
 
-   #set up the outfile
-   if os.path.isfile(outfile): os.remove(outfile)
-   
-   arr=im_arr.copy()
-   arr=CreateImage(spec, rss)
-   arr=arr*im_arr.max()/spec.flux.max()
-   writeout(arr, outfile)
+    rssmodel.set_camera(name='RSS', focallength=330.0)
+    rss = rssmodel.rss
+
+    # set up the outfile
+    if os.path.isfile(outfile):
+        os.remove(outfile)
+
+    arr = im_arr.copy()
+    arr = CreateImage(spec, rss)
+    arr = arr * im_arr.max() / spec.flux.max()
+    writeout(arr, outfile)
 
 test_CreateImage()

--- a/PySpectrograph/unit_tests/ut_Functions.py
+++ b/PySpectrograph/unit_tests/ut_Functions.py
@@ -7,40 +7,40 @@ from mpl_toolkits.mplot3d import Axes3D
 
 def test_normal():
 
-   xarr=np.arange(-25, 25,0.1)
-   arr=np.indices([50,50])-25
-   d3arr=np.indices([50,50,50])-25
-   #create a 1-D gaussian
-   g1d=Normal(xarr, 10,5, 15)
-   pl.figure(figsize=(10,10))
-   pl.axes([0.1, 0.6, 0.8, 0.3])
-   pl.plot(xarr, g1d)
+    xarr = np.arange(-25, 25, 0.1)
+    arr = np.indices([50, 50]) - 25
+    d3arr = np.indices([50, 50, 50]) - 25
+    # create a 1-D gaussian
+    g1d = Normal(xarr, 10, 5, 15)
+    pl.figure(figsize=(10, 10))
+    pl.axes([0.1, 0.6, 0.8, 0.3])
+    pl.plot(xarr, g1d)
 
-   #create a 2-D gaussian
-   g2d=Normal(arr, np.array([10,0]), np.array([5,10]), 15)
-   pl.axes([0.1, 0.1, 0.3, 0.3])
-   zmap=np.product(g2d, axis=0)
-   pl.imshow(zmap)
+    # create a 2-D gaussian
+    g2d = Normal(arr, np.array([10, 0]), np.array([5, 10]), 15)
+    pl.axes([0.1, 0.1, 0.3, 0.3])
+    zmap = np.product(g2d, axis=0)
+    pl.imshow(zmap)
 
-   #create a 3-D gaussian
-   g3d=Normal(d3arr, 10, 5, 15)
-   z3map=np.product(g3d, axis=0)
-   m3d=z3map[35].max()
-   pl.axes([0.5, 0.1, 0.2, 0.2])
-   pl.imshow(z3map[10],vmin=0, vmax=m3d)
-   pl.axes([0.5, 0.35, 0.2, 0.2])
-   pl.imshow(z3map[33],vmin=0, vmax=m3d)
-   pl.axes([0.75, 0.1, 0.2, 0.2])
-   pl.imshow(z3map[35],vmin=0, vmax=m3d)
-   pl.axes([0.75, 0.35, 0.2, 0.2])
-   pl.imshow(z3map[37],vmin=0, vmax=m3d)
-   #test error that mean is the wrong number of dimensions
-   try:
-       g2d=Normal(arr, np.array([10,10,0]), np.array([5,10]), 15)
-   except FunctionsError:
-       pass
-   
-   pl.show()
+    # create a 3-D gaussian
+    g3d = Normal(d3arr, 10, 5, 15)
+    z3map = np.product(g3d, axis=0)
+    m3d = z3map[35].max()
+    pl.axes([0.5, 0.1, 0.2, 0.2])
+    pl.imshow(z3map[10], vmin=0, vmax=m3d)
+    pl.axes([0.5, 0.35, 0.2, 0.2])
+    pl.imshow(z3map[33], vmin=0, vmax=m3d)
+    pl.axes([0.75, 0.1, 0.2, 0.2])
+    pl.imshow(z3map[35], vmin=0, vmax=m3d)
+    pl.axes([0.75, 0.35, 0.2, 0.2])
+    pl.imshow(z3map[37], vmin=0, vmax=m3d)
+    # test error that mean is the wrong number of dimensions
+    try:
+        g2d = Normal(arr, np.array([10, 10, 0]), np.array([5, 10]), 15)
+    except FunctionsError:
+        pass
+
+    pl.show()
 
 
 test_normal()

--- a/PySpectrograph/unit_tests/ut_Identify.py
+++ b/PySpectrograph/unit_tests/ut_Identify.py
@@ -2,34 +2,42 @@
 import pyfits
 import numpy as np
 
-inimage='fmbxpP200610180009.fits'
+inimage = 'fmbxpP200610180009.fits'
 
-xp=np.array([1134.87, 1239.11, 1498.22, 1687.21, 1904.49, 1997.15, 2025.77, 2202.59, 2559.72, 2673.74, 3124.34])
-wp=np.array([4500.9772, 4524.6805, 4582.7474, 4624.2757, 4671.226, 4690.9711, 4697.02, 4734.1524, 4807.019, 4829.709
-,  4916.51] )
+xp = np.array([1134.87, 1239.11, 1498.22, 1687.21, 1904.49, 1997.15, 2025.77, 2202.59, 2559.72, 2673.74, 3124.34])
+wp = np.array([4500.9772,
+               4524.6805,
+               4582.7474,
+               4624.2757,
+               4671.226,
+               4690.9711,
+               4697.02,
+               4734.1524,
+               4807.019,
+               4829.709,
+               4916.51])
 
 
 def test_Identify():
-   hdu=pyfits.open(inimage)
-  
-   #create the data arra
-   data=hdu[1].data
+    hdu = pyfits.open(inimage)
 
-   #create the header information
-   instrume=hdu[1].header['INSTRUME'].strip()
-   grating=hdu[1].header['GRATING'].strip()
-   grang=hdu[1].header['GR-ANGLE']
-   arang=hdu[1].header['AR-ANGLE']
-   filter=hdu[1].header['FILTER'].strip() 
-   slit=float(hdu[1].header['MASKID'])
-   xbin, ybin = hdu[1].header['CCDSUM'].strip().split()
+    # create the data arra
+    data = hdu[1].data
 
-   print instrume, grating, grang, arang, filter
-   print xbin, ybin
-   print len(data), len(data[0])
+    # create the header information
+    instrume = hdu[1].header['INSTRUME'].strip()
+    grating = hdu[1].header['GRATING'].strip()
+    grang = hdu[1].header['GR-ANGLE']
+    arang = hdu[1].header['AR-ANGLE']
+    filter = hdu[1].header['FILTER'].strip()
+    slit = float(hdu[1].header['MASKID'])
+    xbin, ybin = hdu[1].header['CCDSUM'].strip().split()
 
-   #create the RSS Model
-   rssmodel=RSSModel.RSSModel(grating_name=grating, gratang=grang, \
-                              camang=arang,slit=slit, xbin=int(xbin),   \
-                              ybin=int(ybin))
+    print instrume, grating, grang, arang, filter
+    print xbin, ybin
+    print len(data), len(data[0])
 
+    # create the RSS Model
+    rssmodel = RSSModel.RSSModel(grating_name=grating, gratang=grang,
+                                 camang=arang, slit=slit, xbin=int(xbin),
+                                 ybin=int(ybin))

--- a/PySpectrograph/unit_tests/ut_ImageSolution.py
+++ b/PySpectrograph/unit_tests/ut_ImageSolution.py
@@ -1,5 +1,5 @@
 
-"""Unit Test for ImageSolution.  ImageSolution will calculate the 
+"""Unit Test for ImageSolution.  ImageSolution will calculate the
    best spectrograph design given an input spectrograph and data array
 
 """
@@ -10,44 +10,44 @@ from ImageSolution import ImageSolution
 import RSSModel
 import Spectrum
 
-inimage='fmbxpP200610180009.fits'
-inspectra='Xe.dat'
+inimage = 'fmbxpP200610180009.fits'
+inspectra = 'Xe.dat'
+
 
 def test_imagesolution():
-   #load the image and determine its spectrograph parameters
-   hdu=pyfits.open(inimage)
-  
-   #create the data arra
-   data=hdu[1].data
+    # load the image and determine its spectrograph parameters
+    hdu = pyfits.open(inimage)
 
-   #create the header information
-   instrume=hdu[1].header['INSTRUME'].strip()
-   grating=hdu[1].header['GRATING'].strip()
-   grang=hdu[1].header['GR-ANGLE']
-   arang=hdu[1].header['AR-ANGLE']
-   filter=hdu[1].header['FILTER'].strip() 
-   slit=float(hdu[1].header['MASKID'])
-   xbin, ybin = hdu[1].header['CCDSUM'].strip().split()
+    # create the data arra
+    data = hdu[1].data
 
-   print instrume, grating, grang, arang, filter
-   print xbin, ybin
+    # create the header information
+    instrume = hdu[1].header['INSTRUME'].strip()
+    grating = hdu[1].header['GRATING'].strip()
+    grang = hdu[1].header['GR-ANGLE']
+    arang = hdu[1].header['AR-ANGLE']
+    filter = hdu[1].header['FILTER'].strip()
+    slit = float(hdu[1].header['MASKID'])
+    xbin, ybin = hdu[1].header['CCDSUM'].strip().split()
 
-   #create the RSS Model
-   rssmodel=RSSModel.RSSModel(grating_name=grating, gratang=grang, \
-                              camang=arang,slit=slit, xbin=int(xbin),   \
-                              ybin=int(ybin))
+    print instrume, grating, grang, arang, filter
+    print xbin, ybin
 
-   #create the spectrum
-   stype='line'
-   w,s=np.loadtxt(inspectra, usecols=(0,1),unpack=True)
-   spec=Spectrum.Spectrum(w, s, wrange=[4000, 5000], dw=0.1, stype='line')
+    # create the RSS Model
+    rssmodel = RSSModel.RSSModel(grating_name=grating, gratang=grang,
+                                 camang=arang, slit=slit, xbin=int(xbin),
+                                 ybin=int(ybin))
 
+    # create the spectrum
+    stype = 'line'
+    w, s = np.loadtxt(inspectra, usecols=(0, 1), unpack=True)
+    spec = Spectrum.Spectrum(w, s, wrange=[4000, 5000], dw=0.1, stype='line')
 
-   #Now having the model and the data, set up the variables
-   imsol=ImageSolution(data, rssmodel.rss, spec)
-   #imsol.fit()
-   #for i in imsol.coef:
-   #    print imsol.coef[i]()
+    # Now having the model and the data, set up the variables
+    imsol = ImageSolution(data, rssmodel.rss, spec)
+    # imsol.fit()
+    # for i in imsol.coef:
+    #    print imsol.coef[i]()
 
 
 test_imagesolution()

--- a/PySpectrograph/unit_tests/ut_LineFit.py
+++ b/PySpectrograph/unit_tests/ut_LineFit.py
@@ -6,79 +6,88 @@ from PySpectrograph.WavelengthSolution import LineFit as LF
 from PySpectrograph.Models import RSSModel
 from PySpectrograph.Spectra import Spectrum
 
-inimage='fmbxpP200610180009.fits'
-inspectra='Xe.dat'
+inimage = 'fmbxpP200610180009.fits'
+inspectra = 'Xe.dat'
 
 
-xp=np.array([1134.87, 1239.11, 1498.22, 1687.21, 1904.49, 1997.15, 2025.77, 2202.59, 2559.72, 2673.74, 3124.34])
-wp=np.array([4500.9772, 4524.6805, 4582.7474, 4624.2757, 4671.226, 4690.9711, 4697.02, 4734.1524, 4807.019, 4829.709,  4916.51] )
-ep=xp*0.0+0.1
+xp = np.array([1134.87, 1239.11, 1498.22, 1687.21, 1904.49, 1997.15, 2025.77, 2202.59, 2559.72, 2673.74, 3124.34])
+wp = np.array([4500.9772,
+               4524.6805,
+               4582.7474,
+               4624.2757,
+               4671.226,
+               4690.9711,
+               4697.02,
+               4734.1524,
+               4807.019,
+               4829.709,
+               4916.51])
+ep = xp * 0.0 + 0.1
+
 
 def test_Linefit():
 
-   hdu=pyfits.open(inimage)
+    hdu = pyfits.open(inimage)
 
-   #create the data arra
-   data=hdu[1].data
+    # create the data arra
+    data = hdu[1].data
 
-   #create the header information
-   instrume=hdu[1].header['INSTRUME'].strip()
-   grating=hdu[1].header['GRATING'].strip()
-   grang=hdu[1].header['GR-ANGLE']
-   arang=hdu[1].header['AR-ANGLE']
-   filter=hdu[1].header['FILTER'].strip()
-   slit=float(hdu[1].header['MASKID'])
-   xbin, ybin = hdu[1].header['CCDSUM'].strip().split()
+    # create the header information
+    instrume = hdu[1].header['INSTRUME'].strip()
+    grating = hdu[1].header['GRATING'].strip()
+    grang = hdu[1].header['GR-ANGLE']
+    arang = hdu[1].header['AR-ANGLE']
+    filter = hdu[1].header['FILTER'].strip()
+    slit = float(hdu[1].header['MASKID'])
+    xbin, ybin = hdu[1].header['CCDSUM'].strip().split()
 
-   #print instrume, grating, grang, arang, filter
-   #print xbin, ybin
-   #print len(data), len(data[0])
+    # print instrume, grating, grang, arang, filter
+    # print xbin, ybin
+    # print len(data), len(data[0])
 
-   #create the RSS Model
-   rssmodel=RSSModel.RSSModel(grating_name=grating, gratang=grang, \
-                              camang=arang,slit=slit, xbin=int(xbin),   \
-                              ybin=int(ybin))
-   alpha=rssmodel.rss.gratang
-   beta=rssmodel.rss.gratang-rssmodel.rss.camang
+    # create the RSS Model
+    rssmodel = RSSModel.RSSModel(grating_name=grating, gratang=grang,
+                                 camang=arang, slit=slit, xbin=int(xbin),
+                                 ybin=int(ybin))
+    alpha = rssmodel.rss.gratang
+    beta = rssmodel.rss.gratang - rssmodel.rss.camang
 
-   sigma=1e7*rssmodel.rss.calc_resolelement(alpha, beta)
+    sigma = 1e7 * rssmodel.rss.calc_resolelement(alpha, beta)
 
-   #create the observed spectrum
-   midpoint=int(0.5*len(data))
-   xarr=np.arange(len(data[0]), dtype='float')
-   farr=data[midpoint,:]
-   obs_spec=Spectrum(xarr, farr, stype='continuum')
+    # create the observed spectrum
+    midpoint = int(0.5 * len(data))
+    xarr = np.arange(len(data[0]), dtype='float')
+    farr = data[midpoint, :]
+    obs_spec = Spectrum(xarr, farr, stype='continuum')
 
-   #create artificial spectrum
-   stype='line'
-   w,s=np.loadtxt(inspectra, usecols=(0,1),unpack=True)
-   cal_spec=Spectrum(w, s, wrange=[4000, 5000], dw=0.1, stype='line', sigma=sigma)
-   cal_spec.flux=cal_spec.set_dispersion(sigma=sigma)
-   cal_spec.flux=cal_spec.flux*obs_spec.flux.max()/cal_spec.flux.max()+1
+    # create artificial spectrum
+    stype = 'line'
+    w, s = np.loadtxt(inspectra, usecols=(0, 1), unpack=True)
+    cal_spec = Spectrum(w, s, wrange=[4000, 5000], dw=0.1, stype='line', sigma=sigma)
+    cal_spec.flux = cal_spec.set_dispersion(sigma=sigma)
+    cal_spec.flux = cal_spec.flux * obs_spec.flux.max() / cal_spec.flux.max() + 1
 
-   lf=LF.LineFit(obs_spec, cal_spec, function='legendre', order=3)
-   lf.set_coef([  4.23180070e+03,   2.45517852e-01,  -4.46931562e-06,  -2.22067766e-10])
-   print lf(2000)
-   print lf.obs_spec.get_flux(2000), lf.flux(2000)
-   print 'chisq ', (lf.errfit(lf.coef, xarr, farr)**2).sum()/1e7
-   lf.set_coef([  4.23280070e+03,   2.45517852e-01,  -4.46931562e-06,  -2.22067766e-10])
-   print lf(2000)
-   print lf.obs_spec.get_flux(2000), lf.flux(2000)
-   print 'chisq ',(lf.errfit(lf.coef, xarr, farr)**2).sum()/1e7
-   #print lf.lfit(xarr)
-   #print lf.coef
-   #print lf(2000)
-   #print lf.results
+    lf = LF.LineFit(obs_spec, cal_spec, function='legendre', order=3)
+    lf.set_coef([4.23180070e+03, 2.45517852e-01, -4.46931562e-06, -2.22067766e-10])
+    print lf(2000)
+    print lf.obs_spec.get_flux(2000), lf.flux(2000)
+    print 'chisq ', (lf.errfit(lf.coef, xarr, farr) ** 2).sum() / 1e7
+    lf.set_coef([4.23280070e+03, 2.45517852e-01, -4.46931562e-06, -2.22067766e-10])
+    print lf(2000)
+    print lf.obs_spec.get_flux(2000), lf.flux(2000)
+    print 'chisq ', (lf.errfit(lf.coef, xarr, farr) ** 2).sum() / 1e7
+    # print lf.lfit(xarr)
+    # print lf.coef
+    # print lf(2000)
+    # print lf.results
 
-   pl.figure()
-   
-   pl.plot(lf(lf.obs_spec.wavelength), lf.obs_spec.get_flux(xarr))
-   pl.plot(lf.cal_spec.wavelength, lf.cal_spec.flux)
-   pl.show()
-   
-   
+    pl.figure()
+
+    pl.plot(lf(lf.obs_spec.wavelength), lf.obs_spec.get_flux(xarr))
+    pl.plot(lf.cal_spec.wavelength, lf.cal_spec.flux)
+    pl.show()
 
 
-#test_LineSolution()
-#test_ModelSolution()
+# test_LineSolution()
+# test_ModelSolution()
 test_Linefit()

--- a/PySpectrograph/unit_tests/ut_LineSolution.py
+++ b/PySpectrograph/unit_tests/ut_LineSolution.py
@@ -4,21 +4,31 @@ import pylab as pl
 
 from PySpectrograph.WavelengthSolution import LineSolution as LS
 
-xp=np.array([1134.87, 1239.11, 1498.22, 1687.21, 1904.49, 1997.15, 2025.77, 2202.59, 2559.72, 2673.74, 3124.34])
-wp=np.array([4500.9772, 4524.6805, 4582.7474, 4624.2757, 4671.226, 4690.9711, 4697.02, 4734.1524, 4807.019, 4829.709,  4916.51] )
+xp = np.array([1134.87, 1239.11, 1498.22, 1687.21, 1904.49, 1997.15, 2025.77, 2202.59, 2559.72, 2673.74, 3124.34])
+wp = np.array([4500.9772,
+               4524.6805,
+               4582.7474,
+               4624.2757,
+               4671.226,
+               4690.9711,
+               4697.02,
+               4734.1524,
+               4807.019,
+               4829.709,
+               4916.51])
 
 
 def test_LineSolution():
-   ls=LS.LineSolution(xp, wp, function='legendre')
-   ls.interfit()
-   print ls.coef
-   print ls.sigma(ls.x, ls.y)
-   print ls.value(2000)
+    ls = LS.LineSolution(xp, wp, function='legendre')
+    ls.interfit()
+    print ls.coef
+    print ls.sigma(ls.x, ls.y)
+    print ls.value(2000)
 
-   pl.figure()
-   pl.plot(xp, wp-ls(xp), ls='', marker='o')
-   pl.plot(ls.x, ls.y-ls(ls.x), ls='', marker='o')
-   pl.show()
-   return
+    pl.figure()
+    pl.plot(xp, wp - ls(xp), ls='', marker='o')
+    pl.plot(ls.x, ls.y - ls(ls.x), ls='', marker='o')
+    pl.show()
+    return
 
 test_LineSolution()

--- a/PySpectrograph/unit_tests/ut_ModelFit.py
+++ b/PySpectrograph/unit_tests/ut_ModelFit.py
@@ -1,6 +1,6 @@
 
-"""Unit Test for LineSolution.  LineSolution will calculate the 
-   best spectrograph design given an input spectrograph and spectrum 
+"""Unit Test for LineSolution.  LineSolution will calculate the
+   best spectrograph design given an input spectrograph and spectrum
 
 """
 import pyfits
@@ -10,105 +10,115 @@ from LineSolution import LineSolution
 import RSSModel
 import Spectrum
 
-inimage='fmbxpP200610180009.fits'
-inspectra='Xe.dat'
+inimage = 'fmbxpP200610180009.fits'
+inspectra = 'Xe.dat'
 
 import pylab as pl
 
-xp=np.array([1134.87, 1239.11, 1498.22, 1687.21, 1904.49, 1997.15, 2025.77, 2202.59, 2559.72, 2673.74, 3124.34])
-wp=np.array([4500.9772, 4524.6805, 4582.7474, 4624.2757, 4671.226, 4690.9711, 4697.02, 4734.1524, 4807.019, 4829.709,  4916.51] )
+xp = np.array([1134.87, 1239.11, 1498.22, 1687.21, 1904.49, 1997.15, 2025.77, 2202.59, 2559.72, 2673.74, 3124.34])
+wp = np.array([4500.9772,
+               4524.6805,
+               4582.7474,
+               4624.2757,
+               4671.226,
+               4690.9711,
+               4697.02,
+               4734.1524,
+               4807.019,
+               4829.709,
+               4916.51])
+
+
 def test_imagesolution():
-   #load the image and determine its spectrograph parameters
-   hdu=pyfits.open(inimage)
-  
-   #create the data arra
-   data=hdu[1].data
+    # load the image and determine its spectrograph parameters
+    hdu = pyfits.open(inimage)
 
-   #create the header information
-   instrume=hdu[1].header['INSTRUME'].strip()
-   grating=hdu[1].header['GRATING'].strip()
-   grang=hdu[1].header['GR-ANGLE']
-   arang=hdu[1].header['AR-ANGLE']
-   filter=hdu[1].header['FILTER'].strip() 
-   slit=float(hdu[1].header['MASKID'])
-   xbin, ybin = hdu[1].header['CCDSUM'].strip().split()
+    # create the data arra
+    data = hdu[1].data
 
-   print instrume, grating, grang, arang, filter
-   print xbin, ybin
+    # create the header information
+    instrume = hdu[1].header['INSTRUME'].strip()
+    grating = hdu[1].header['GRATING'].strip()
+    grang = hdu[1].header['GR-ANGLE']
+    arang = hdu[1].header['AR-ANGLE']
+    filter = hdu[1].header['FILTER'].strip()
+    slit = float(hdu[1].header['MASKID'])
+    xbin, ybin = hdu[1].header['CCDSUM'].strip().split()
 
-   #create the RSS Model
-   rssmodel=RSSModel.RSSModel(grating_name=grating, gratang=grang, \
-                              camang=arang,slit=slit, xbin=int(xbin),   \
-                              ybin=int(ybin))
-   alpha=rssmodel.rss.gratang
-   beta=rssmodel.rss.gratang-rssmodel.rss.camang
+    print instrume, grating, grang, arang, filter
+    print xbin, ybin
 
-   sigma=1e7*rssmodel.rss.calc_resolelement(alpha, beta)
+    # create the RSS Model
+    rssmodel = RSSModel.RSSModel(grating_name=grating, gratang=grang,
+                                 camang=arang, slit=slit, xbin=int(xbin),
+                                 ybin=int(ybin))
+    alpha = rssmodel.rss.gratang
+    beta = rssmodel.rss.gratang - rssmodel.rss.camang
 
-   #create the spectrum
-   stype='line'
-   w,s=np.loadtxt(inspectra, usecols=(0,1),unpack=True)
-   spec=Spectrum.Spectrum(w, s, wrange=[4000, 5000], dw=0.1, stype='line', sigma=sigma)
-   #spec.flux=spec.set_dispersion(sigma=sigma)
+    sigma = 1e7 * rssmodel.rss.calc_resolelement(alpha, beta)
 
+    # create the spectrum
+    stype = 'line'
+    w, s = np.loadtxt(inspectra, usecols=(0, 1), unpack=True)
+    spec = Spectrum.Spectrum(w, s, wrange=[4000, 5000], dw=0.1, stype='line', sigma=sigma)
+    # spec.flux=spec.set_dispersion(sigma=sigma)
 
-   #Now having the model and the data, set up the variables
-   j=int(len(data)/2)
-   xlen=len(data[0])
-   xarr=np.arange(len(data[0]))
-   farr=data[j,:]
-   var=abs(farr)+farr.mean()
-   var=var*(farr>1000)+1
+    # Now having the model and the data, set up the variables
+    j = int(len(data) / 2)
+    xlen = len(data[0])
+    xarr = np.arange(len(data[0]))
+    farr = data[j, :]
+    var = abs(farr) + farr.mean()
+    var = var * (farr > 1000) + 1
 
-   if 1:
-       imsol=LineSolution(rssmodel.rss, xarr=xarr, farr=farr, spectrum=spec, yval=0, var=var, order=2)
-       output=imsol.fit(imsol.makeflux, imsol.coef, imsol.xarr, imsol.farr, imsol.var)
-       #imsol.fit(imsol.makeflux, imsol.ndcoef, imsol.xarr, imsol.farr, imsol.var)
-       #imsol.fit(imsol.makeflux, imsol.coef, imsol.xarr, imsol.farr, imsol.var)
-       #for i in range(len(imsol.coef)):
-       #    print imsol.coef[i]()
-       #for i in range(len(imsol.ndcoef)):
-       #    print imsol.ndcoef[i]()
+    if 1:
+        imsol = LineSolution(rssmodel.rss, xarr=xarr, farr=farr, spectrum=spec, yval=0, var=var, order=2)
+        output = imsol.fit(imsol.makeflux, imsol.coef, imsol.xarr, imsol.farr, imsol.var)
+        #imsol.fit(imsol.makeflux, imsol.ndcoef, imsol.xarr, imsol.farr, imsol.var)
+        #imsol.fit(imsol.makeflux, imsol.coef, imsol.xarr, imsol.farr, imsol.var)
+        # for i in range(len(imsol.coef)):
+        #    print imsol.coef[i]()
+        # for i in range(len(imsol.ndcoef)):
+        #    print imsol.ndcoef[i]()
 
-       print output.beta
-       print imsol.value(output.beta, 500)
+        print output.beta
+        print imsol.value(output.beta, 500)
 
-       #check the results
-       warr=imsol.value(output.beta, imsol.xarr)
-       print (wp-imsol.value(output.beta, xp)).mean(), (wp-imsol.value(output.beta, xp)).std()
-       pl.figure()
-       pl.plot(imsol.spectrum.wavelength, imsol.spectrum.flux*imsol.farr.max()/imsol.spectrum.flux.max())
-       pl.plot(warr, imsol.farr)
-       #pl.plot(xp, wp-imsol.value(xp), ls='', marker='o')
-       pl.show()
+        # check the results
+        warr = imsol.value(output.beta, imsol.xarr)
+        print (wp - imsol.value(output.beta, xp)).mean(), (wp - imsol.value(output.beta, xp)).std()
+        pl.figure()
+        pl.plot(imsol.spectrum.wavelength, imsol.spectrum.flux * imsol.farr.max() / imsol.spectrum.flux.max())
+        pl.plot(warr, imsol.farr)
+        #pl.plot(xp, wp-imsol.value(xp), ls='', marker='o')
+        pl.show()
 
-   #okay now test the results for a purely matched lines
-   fp=xp*0.0+2.0
-   var=xp*0.0+1.0
-   xspec=Spectrum.Spectrum(xp, fp, dw=0.1, stype='line', sigma=sigma)
-   wspec=Spectrum.Spectrum(wp, fp, wrange=[4000, 5000], dw=0.1, stype='line', sigma=sigma)
+    # okay now test the results for a purely matched lines
+    fp = xp * 0.0 + 2.0
+    var = xp * 0.0 + 1.0
+    xspec = Spectrum.Spectrum(xp, fp, dw=0.1, stype='line', sigma=sigma)
+    wspec = Spectrum.Spectrum(wp, fp, wrange=[4000, 5000], dw=0.1, stype='line', sigma=sigma)
 
-   imsol=LineSolution(rssmodel.rss, xarr=xspec.wavelength, farr=xspec.flux, spectrum=wspec, yval=0, var=var, order=3)
-   imsol.xlen=xlen
-   output=imsol.fit(imsol.value, imsol.coef, xp, wp, var)
-   print output.beta
-   #imsol.fit(imsol.value, imsol.ndcoef, xp, wp, var)
-   #for i in range(len(imsol.coef)):
-   #print imsol.coef[i])
-   #for i in range(len(imsol.ndcoef)):
-   #    print imsol.ndcoef[i]()
+    imsol = LineSolution(rssmodel.rss, xarr=xspec.wavelength, farr=xspec.flux, spectrum=wspec, yval=0, var=var, order=3)
+    imsol.xlen = xlen
+    output = imsol.fit(imsol.value, imsol.coef, xp, wp, var)
+    print output.beta
+    #imsol.fit(imsol.value, imsol.ndcoef, xp, wp, var)
+    # for i in range(len(imsol.coef)):
+    # print imsol.coef[i])
+    # for i in range(len(imsol.ndcoef)):
+    #    print imsol.ndcoef[i]()
 
-   print imsol.value(output.beta, 500)
-   print (wp-imsol.value(output.beta, xp)).mean(), (wp-imsol.value(output.beta, xp)).std()
+    print imsol.value(output.beta, 500)
+    print (wp - imsol.value(output.beta, xp)).mean(), (wp - imsol.value(output.beta, xp)).std()
 
-   #check the results
-   warr=imsol.value(output.beta, xarr)
-   pl.figure()
-   pl.plot(spec.wavelength, spec.flux*farr.max()/spec.flux.max())
-   pl.plot(warr, farr)
-   #pl.plot(xp, wp-imsol.value(output.beta, xp), ls='', marker='o')
-   pl.show()
-   
-   
+    # check the results
+    warr = imsol.value(output.beta, xarr)
+    pl.figure()
+    pl.plot(spec.wavelength, spec.flux * farr.max() / spec.flux.max())
+    pl.plot(warr, farr)
+    #pl.plot(xp, wp-imsol.value(output.beta, xp), ls='', marker='o')
+    pl.show()
+
 
 test_imagesolution()

--- a/PySpectrograph/unit_tests/ut_ModelSolution.py
+++ b/PySpectrograph/unit_tests/ut_ModelSolution.py
@@ -5,52 +5,62 @@ import pylab as pl
 from PySpectrograph.Models import RSSModel
 from PySpectrograph.WavelengthSolution import ModelSolution as MS
 
-inimage='fmbxpP200610180009.fits'
+inimage = 'fmbxpP200610180009.fits'
 
-xp=np.array([1134.87, 1239.11, 1498.22, 1687.21, 1904.49, 1997.15, 2025.77, 2202.59, 2559.72, 2673.74, 3124.34])
-wp=np.array([4500.9772, 4524.6805, 4582.7474, 4624.2757, 4671.226, 4690.9711, 4697.02, 4734.1524, 4807.019, 4829.709,  4916.51] )
+xp = np.array([1134.87, 1239.11, 1498.22, 1687.21, 1904.49, 1997.15, 2025.77, 2202.59, 2559.72, 2673.74, 3124.34])
+wp = np.array([4500.9772,
+               4524.6805,
+               4582.7474,
+               4624.2757,
+               4671.226,
+               4690.9711,
+               4697.02,
+               4734.1524,
+               4807.019,
+               4829.709,
+               4916.51])
 
 
 def test_ModelSolution():
- 
-   hdu=pyfits.open(inimage)
-  
-   #create the data arra
-   data=hdu[1].data
 
-   #create the header information
-   instrume=hdu[1].header['INSTRUME'].strip()
-   grating=hdu[1].header['GRATING'].strip()
-   grang=hdu[1].header['GR-ANGLE']
-   arang=hdu[1].header['AR-ANGLE']
-   filter=hdu[1].header['FILTER'].strip() 
-   slit=float(hdu[1].header['MASKID'])
-   xbin, ybin = hdu[1].header['CCDSUM'].strip().split()
+    hdu = pyfits.open(inimage)
 
-   print instrume, grating, grang, arang, filter
-   print xbin, ybin
-   print len(data), len(data[0])
+    # create the data arra
+    data = hdu[1].data
 
-   #create the RSS Model
-   rssmodel=RSSModel.RSSModel(grating_name=grating, gratang=grang, \
-                              camang=arang,slit=slit, xbin=int(xbin),   \
-                              ybin=int(ybin))
-  
-   err=xp*0.0+0.1
-   ls=MS.ModelSolution(xp, wp, rssmodel.rss, xlen=len(data[0]), order=4)
-   ls.fit(cfit='all')
-   ls.fit(ls.ndcoef)
-   for c in ls.coef:
-       print c(),
-   print
-   print ls.sigma(ls.x, ls.y)
-   print ls.chisq(ls.x, ls.y, err)
-   print ls.value(2000)
+    # create the header information
+    instrume = hdu[1].header['INSTRUME'].strip()
+    grating = hdu[1].header['GRATING'].strip()
+    grang = hdu[1].header['GR-ANGLE']
+    arang = hdu[1].header['AR-ANGLE']
+    filter = hdu[1].header['FILTER'].strip()
+    slit = float(hdu[1].header['MASKID'])
+    xbin, ybin = hdu[1].header['CCDSUM'].strip().split()
 
-   pl.figure()
-   pl.plot(xp, wp-ls.value(xp), ls='', marker='o')
-   #pl.plot(ls.x, ls.y-ls(ls.x), ls='', marker='o')
-   pl.show()
-   return
+    print instrume, grating, grang, arang, filter
+    print xbin, ybin
+    print len(data), len(data[0])
+
+    # create the RSS Model
+    rssmodel = RSSModel.RSSModel(grating_name=grating, gratang=grang,
+                                 camang=arang, slit=slit, xbin=int(xbin),
+                                 ybin=int(ybin))
+
+    err = xp * 0.0 + 0.1
+    ls = MS.ModelSolution(xp, wp, rssmodel.rss, xlen=len(data[0]), order=4)
+    ls.fit(cfit='all')
+    ls.fit(ls.ndcoef)
+    for c in ls.coef:
+        print c(),
+    print
+    print ls.sigma(ls.x, ls.y)
+    print ls.chisq(ls.x, ls.y, err)
+    print ls.value(2000)
+
+    pl.figure()
+    pl.plot(xp, wp - ls.value(xp), ls='', marker='o')
+    #pl.plot(ls.x, ls.y-ls(ls.x), ls='', marker='o')
+    pl.show()
+    return
 
 test_ModelSolution()

--- a/PySpectrograph/unit_tests/ut_RssModel.py
+++ b/PySpectrograph/unit_tests/ut_RssModel.py
@@ -1,6 +1,6 @@
 
-"""Unit Test for LineSolution.  LineSolution will calculate the 
-   best spectrograph design given an input spectrograph and spectrum 
+"""Unit Test for LineSolution.  LineSolution will calculate the
+   best spectrograph design given an input spectrograph and spectrum
 
 """
 import pyfits
@@ -8,44 +8,43 @@ import numpy as np
 
 from PySpectrograph.Models import RSSModel
 
-inimage='fmbxpP200610180009.fits'
-inspectra='Xe.dat'
+inimage = 'fmbxpP200610180009.fits'
+inspectra = 'Xe.dat'
 
 
 def test_rssmodel():
-   #load the image and determine its spectrograph parameters
-   hdu=pyfits.open(inimage)
-  
-   #create the data arra
-   data=hdu[1].data
+    # load the image and determine its spectrograph parameters
+    hdu = pyfits.open(inimage)
 
-   #create the header information
-   instrume=hdu[1].header['INSTRUME'].strip()
-   grating=hdu[1].header['GRATING'].strip()
-   grang=hdu[1].header['GR-ANGLE']
-   arang=hdu[1].header['AR-ANGLE']
-   filter=hdu[1].header['FILTER'].strip() 
-   slit=float(hdu[1].header['MASKID'])
-   xbin, ybin = hdu[1].header['CCDSUM'].strip().split()
+    # create the data arra
+    data = hdu[1].data
 
+    # create the header information
+    instrume = hdu[1].header['INSTRUME'].strip()
+    grating = hdu[1].header['GRATING'].strip()
+    grang = hdu[1].header['GR-ANGLE']
+    arang = hdu[1].header['AR-ANGLE']
+    filter = hdu[1].header['FILTER'].strip()
+    slit = float(hdu[1].header['MASKID'])
+    xbin, ybin = hdu[1].header['CCDSUM'].strip().split()
 
-   #create the RSS Model
-   rss=RSSModel.RSSModel(grating_name=grating, gratang=grang, \
-                              camang=arang,slit=slit, xbin=int(xbin),   \
-                              ybin=int(ybin))
-   alpha=rss.alpha()
-   beta=rss.beta()
+    # create the RSS Model
+    rss = RSSModel.RSSModel(grating_name=grating, gratang=grang,
+                            camang=arang, slit=slit, xbin=int(xbin),
+                            ybin=int(ybin))
+    alpha = rss.alpha()
+    beta = rss.beta()
 
-   sigma=1e7*rss.calc_resolelement(alpha, beta)
-   print "SIGMA: ", sigma
+    sigma = 1e7 * rss.calc_resolelement(alpha, beta)
+    print "SIGMA: ", sigma
 
-   #test to see if giving the wrong name it will raise an error
-   try:
-       rss=RSSModel.RSSModel(grating_name="not a grating", gratang=grang, \
-                              camang=arang,slit=slit, xbin=int(xbin),   \
-                              ybin=int(ybin))
-   except RSSModel.RSSError, e:
-       pass
-   
+    # test to see if giving the wrong name it will raise an error
+    try:
+        rss = RSSModel.RSSModel(grating_name="not a grating", gratang=grang,
+                                camang=arang, slit=slit, xbin=int(xbin),
+                                ybin=int(ybin))
+    except RSSModel.RSSError as e:
+        pass
+
 
 test_rssmodel()

--- a/PySpectrograph/unit_tests/ut_Spectrum.py
+++ b/PySpectrograph/unit_tests/ut_Spectrum.py
@@ -3,50 +3,52 @@ from PySpectrograph import Spectrum
 import numpy as np
 import pylab as pl
 
-infile='Xe.10.spec'
-inlist='Xe.dat'
-oneline='one.line'
+infile = 'Xe.10.spec'
+inlist = 'Xe.dat'
+oneline = 'one.line'
+
 
 def test_spectrum():
-   print 'testing spectrum...'
+    print 'testing spectrum...'
 
-   #create a spectrum from a single line
-   w,f=np.loadtxt(oneline, usecols=(0,1),unpack=True)
-   sp1=Spectrum.Spectrum([w], [f], wrange=[4500, 4900], sigma=1)
-   pl.figure(figsize=(10,10))
-   pl.axes([0.1, 0.1, 0.8, 0.8])
-   pl.plot(sp1.wavelength,sp1.flux)
+    # create a spectrum from a single line
+    w, f = np.loadtxt(oneline, usecols=(0, 1), unpack=True)
+    sp1 = Spectrum.Spectrum([w], [f], wrange=[4500, 4900], sigma=1)
+    pl.figure(figsize=(10, 10))
+    pl.axes([0.1, 0.1, 0.8, 0.8])
+    pl.plot(sp1.wavelength, sp1.flux)
 
-   #create a spectrum from a line list
-   w,f=np.loadtxt(inlist, usecols=(0,1),unpack=True)
-   spl=Spectrum.Spectrum(w, f, sigma=5)
-   pl.plot(spl.wavelength,spl.flux)
+    # create a spectrum from a line list
+    w, f = np.loadtxt(inlist, usecols=(0, 1), unpack=True)
+    spl = Spectrum.Spectrum(w, f, sigma=5)
+    pl.plot(spl.wavelength, spl.flux)
 
-   #create a spectrum from a spectrum
-   w,f=np.loadtxt(infile, usecols=(0,1),unpack=True)
-   spf=Spectrum.Spectrum(w, f, sigma=5, stype='continuum')
-   pl.plot(spf.wavelength,spf.flux)
+    # create a spectrum from a spectrum
+    w, f = np.loadtxt(infile, usecols=(0, 1), unpack=True)
+    spf = Spectrum.Spectrum(w, f, sigma=5, stype='continuum')
+    pl.plot(spf.wavelength, spf.flux)
 
-   #test error that mean is the wrong number of dimensions
-   pl.savefig('out.png')
-   pl.show()
+    # test error that mean is the wrong number of dimensions
+    pl.savefig('out.png')
+    pl.show()
+
 
 def test_vacuum():
-    #test code to change vacuum to air wavlengths and back again
-    #test case form IDL script
-    w_air=6056.125
-    w_vac=6057.8019
-    if abs(Spectrum.air2vac(w_air, mode='Morton')-w_vac)>0.01: 
-       print "ERROR in MORTON AIR2VAC calculation"
-    if abs(Spectrum.air2vac(w_air, mode='Ciddor')-w_vac)>0.01: 
-       print "ERROR in CIDDOR AIR2VAC calculation"
+    # test code to change vacuum to air wavlengths and back again
+    # test case form IDL script
+    w_air = 6056.125
+    w_vac = 6057.8019
+    if abs(Spectrum.air2vac(w_air, mode='Morton') - w_vac) > 0.01:
+        print "ERROR in MORTON AIR2VAC calculation"
+    if abs(Spectrum.air2vac(w_air, mode='Ciddor') - w_vac) > 0.01:
+        print "ERROR in CIDDOR AIR2VAC calculation"
     print w_air, w_vac
-    if abs(Spectrum.vac2air(w_vac, mode='Ciddor')-w_air)>0.01:
-       print "ERROR in CIDDOR VAC2AIR calculation"
-    if abs(Spectrum.vac2air(w_vac, mode='Morton')-w_air)>0.01: 
-       print "ERROR in MORTON VAC2AIR calculation"
+    if abs(Spectrum.vac2air(w_vac, mode='Ciddor') - w_air) > 0.01:
+        print "ERROR in CIDDOR VAC2AIR calculation"
+    if abs(Spectrum.vac2air(w_vac, mode='Morton') - w_air) > 0.01:
+        print "ERROR in MORTON VAC2AIR calculation"
 
-    #check that it works with a 
+    # check that it works with a
 
 test_spectrum()
 test_vacuum()

--- a/PySpectrograph/unit_tests/ut_WavelengthSolution.py
+++ b/PySpectrograph/unit_tests/ut_WavelengthSolution.py
@@ -6,131 +6,146 @@ from PySpectrograph.WavelengthSolution import WavelengthSolution as WS
 from PySpectrograph.Models import RSSModel
 from PySpectrograph.Spectra import Spectrum
 
-inimage='fmbxpP200610180009.fits'
-inspectra='Xe.dat'
+inimage = 'fmbxpP200610180009.fits'
+inspectra = 'Xe.dat'
 
 
-xp=np.array([1134.87, 1239.11, 1498.22, 1687.21, 1904.49, 1997.15, 2025.77, 2202.59, 2559.72, 2673.74, 3124.34])
-wp=np.array([4500.9772, 4524.6805, 4582.7474, 4624.2757, 4671.226, 4690.9711, 4697.02, 4734.1524, 4807.019, 4829.709,  4916.51] )
-ep=xp*0.0+0.1
+xp = np.array([1134.87, 1239.11, 1498.22, 1687.21, 1904.49, 1997.15, 2025.77, 2202.59, 2559.72, 2673.74, 3124.34])
+wp = np.array([4500.9772,
+               4524.6805,
+               4582.7474,
+               4624.2757,
+               4671.226,
+               4690.9711,
+               4697.02,
+               4734.1524,
+               4807.019,
+               4829.709,
+               4916.51])
+ep = xp * 0.0 + 0.1
+
 
 def test_LineSolution():
-   ws=WS.WavelengthSolution(xp, wp, function='poly')
-   ws.fit()
-   print ws.func.coef
-   print ws.value(2000)
-   print ws.sigma(ws.func.x, ws.func.y)
-   print ws.chisq(ws.func.x, ws.func.y, ws.func.yerr)
+    ws = WS.WavelengthSolution(xp, wp, function='poly')
+    ws.fit()
+    print ws.func.coef
+    print ws.value(2000)
+    print ws.sigma(ws.func.x, ws.func.y)
+    print ws.chisq(ws.func.x, ws.func.y, ws.func.yerr)
 
-   pl.figure()
-   pl.plot(xp, wp-ws.value(xp), ls='', marker='o')
-   #pl.plot(ls.x, ls.y-ls(ls.x), ls='', marker='o')
-   pl.show()
-   return
+    pl.figure()
+    pl.plot(xp, wp - ws.value(xp), ls='', marker='o')
+    #pl.plot(ls.x, ls.y-ls(ls.x), ls='', marker='o')
+    pl.show()
+    return
+
 
 def test_ModelSolution():
 
-   hdu=pyfits.open(inimage)
+    hdu = pyfits.open(inimage)
 
-   #create the data arra
-   data=hdu[1].data
+    # create the data arra
+    data = hdu[1].data
 
-   #create the header information
-   instrume=hdu[1].header['INSTRUME'].strip()
-   grating=hdu[1].header['GRATING'].strip()
-   grang=hdu[1].header['GR-ANGLE']
-   arang=hdu[1].header['AR-ANGLE']
-   filter=hdu[1].header['FILTER'].strip()
-   slit=float(hdu[1].header['MASKID'])
-   xbin, ybin = hdu[1].header['CCDSUM'].strip().split()
+    # create the header information
+    instrume = hdu[1].header['INSTRUME'].strip()
+    grating = hdu[1].header['GRATING'].strip()
+    grang = hdu[1].header['GR-ANGLE']
+    arang = hdu[1].header['AR-ANGLE']
+    filter = hdu[1].header['FILTER'].strip()
+    slit = float(hdu[1].header['MASKID'])
+    xbin, ybin = hdu[1].header['CCDSUM'].strip().split()
 
-   #print instrume, grating, grang, arang, filter
-   #print xbin, ybin
-   #print len(data), len(data[0])
+    # print instrume, grating, grang, arang, filter
+    # print xbin, ybin
+    # print len(data), len(data[0])
 
-   #create the RSS Model
-   rssmodel=RSSModel.RSSModel(grating_name=grating, gratang=grang, \
-                              camang=arang,slit=slit, xbin=int(xbin),   \
-                              ybin=int(ybin))
+    # create the RSS Model
+    rssmodel = RSSModel.RSSModel(grating_name=grating, gratang=grang,
+                                 camang=arang, slit=slit, xbin=int(xbin),
+                                 ybin=int(ybin))
 
-   xarr=np.arange(len(data[0]), dtype='int64')
-   rss=rssmodel.rss
-   alpha=rss.gratang
-   beta=rss.gratang-rss.camang
-   d=rss.detector.xbin*rss.detector.pix_size*(xarr-0.5*len(xarr))
-   dbeta=np.degrees(np.arctan(d/rss.camera.focallength))
-   y=1e7*rss.calc_wavelength(alpha, beta-dbeta)
+    xarr = np.arange(len(data[0]), dtype='int64')
+    rss = rssmodel.rss
+    alpha = rss.gratang
+    beta = rss.gratang - rss.camang
+    d = rss.detector.xbin * rss.detector.pix_size * (xarr - 0.5 * len(xarr))
+    dbeta = np.degrees(np.arctan(d / rss.camera.focallength))
+    y = 1e7 * rss.calc_wavelength(alpha, beta - dbeta)
 
+    #ws=WS.WavelengthSolution(xp, wp, function='model', sgraph=rssmodel.rss, xlen=len(data[0]), order=4, cfit='all')
+    ws = WS.WavelengthSolution(
+        xarr,
+        y,
+        function='model',
+        sgraph=rssmodel.rss,
+        xlen=len(
+            data[0]),
+        order=4,
+        cfit='ndcoef')
 
-   #ws=WS.WavelengthSolution(xp, wp, function='model', sgraph=rssmodel.rss, xlen=len(data[0]), order=4, cfit='all')
-   ws=WS.WavelengthSolution(xarr, y, function='model', sgraph=rssmodel.rss, xlen=len(data[0]), order=4, cfit='ndcoef')
-   
-   #ws=WS.WavelengthSolution(xarr, y, function='poly', order=3)
-   #ws=WS.WavelengthSolution(xp, wp, function='poly', order=3)
+    #ws=WS.WavelengthSolution(xarr, y, function='poly', order=3)
+    #ws=WS.WavelengthSolution(xp, wp, function='poly', order=3)
 
-   ws.fit()
-   print ws.coef
-   print ws.func.result
-   for c in ws.func.spcoef:
-       print c()
-   for c in ws.func.ndcoef:
-       print c()
-   print ws.value(2000)
-   print ws.sigma(xp, wp)
-   print ws.chisq(xp, wp, ep)
+    ws.fit()
+    print ws.coef
+    print ws.func.result
+    for c in ws.func.spcoef:
+        print c()
+    for c in ws.func.ndcoef:
+        print c()
+    print ws.value(2000)
+    print ws.sigma(xp, wp)
+    print ws.chisq(xp, wp, ep)
 
-   pl.figure()
-   #pl.plot(xarr,y)
-   #pl.plot(xarr, ws.value(xarr))
-   #pl.plot(xp, wp-ws.value(xp), ls='', marker='o')
-   pl.plot(xarr, y-ws.value(xarr))
-   #pl.plot(ls.x, ls.y-ls(ls.x), ls='', marker='o')
-   pl.show()
+    pl.figure()
+    # pl.plot(xarr,y)
+    #pl.plot(xarr, ws.value(xarr))
+    #pl.plot(xp, wp-ws.value(xp), ls='', marker='o')
+    pl.plot(xarr, y - ws.value(xarr))
+    #pl.plot(ls.x, ls.y-ls(ls.x), ls='', marker='o')
+    pl.show()
+
 
 def test_Linefit():
 
-   hdu=pyfits.open(inimage)
+    hdu = pyfits.open(inimage)
 
-   #create the data arra
-   data=hdu[1].data
+    # create the data arra
+    data = hdu[1].data
 
-   #create the header information
-   instrume=hdu[1].header['INSTRUME'].strip()
-   grating=hdu[1].header['GRATING'].strip()
-   grang=hdu[1].header['GR-ANGLE']
-   arang=hdu[1].header['AR-ANGLE']
-   filter=hdu[1].header['FILTER'].strip()
-   slit=float(hdu[1].header['MASKID'])
-   xbin, ybin = hdu[1].header['CCDSUM'].strip().split()
+    # create the header information
+    instrume = hdu[1].header['INSTRUME'].strip()
+    grating = hdu[1].header['GRATING'].strip()
+    grang = hdu[1].header['GR-ANGLE']
+    arang = hdu[1].header['AR-ANGLE']
+    filter = hdu[1].header['FILTER'].strip()
+    slit = float(hdu[1].header['MASKID'])
+    xbin, ybin = hdu[1].header['CCDSUM'].strip().split()
 
-   #print instrume, grating, grang, arang, filter
-   #print xbin, ybin
-   #print len(data), len(data[0])
+    # print instrume, grating, grang, arang, filter
+    # print xbin, ybin
+    # print len(data), len(data[0])
 
-   #create the RSS Model
-   rssmodel=RSSModel.RSSModel(grating_name=grating, gratang=grang, \
-                              camang=arang,slit=slit, xbin=int(xbin),   \
-                              ybin=int(ybin))
-   alpha=rssmodel.rss.gratang
-   beta=rssmodel.rss.gratang-rssmodel.rss.camang
+    # create the RSS Model
+    rssmodel = RSSModel.RSSModel(grating_name=grating, gratang=grang,
+                                 camang=arang, slit=slit, xbin=int(xbin),
+                                 ybin=int(ybin))
+    alpha = rssmodel.rss.gratang
+    beta = rssmodel.rss.gratang - rssmodel.rss.camang
 
-   sigma=1e7*rssmodel.rss.calc_resolelement(alpha, beta)
+    sigma = 1e7 * rssmodel.rss.calc_resolelement(alpha, beta)
 
+    # create artificial spectrum
+    # create the spectrum
+    stype = 'line'
+    w, s = np.loadtxt(inspectra, usecols=(0, 1), unpack=True)
+    spec = Spectrum(w, s, wrange=[4000, 5000], dw=0.1, stype='line', sigma=sigma)
+    spec.flux = spec.set_dispersion(sigma=sigma)
 
-   #create artificial spectrum
-   #create the spectrum
-   stype='line'
-   w,s=np.loadtxt(inspectra, usecols=(0,1),unpack=True)
-   spec=Spectrum(w, s, wrange=[4000, 5000], dw=0.1, stype='line', sigma=sigma)
-   spec.flux=spec.set_dispersion(sigma=sigma)
-
-   sw_arr, sf_arr = spec.wavelength, spec.flux
-
-   
-
-   
+    sw_arr, sf_arr = spec.wavelength, spec.flux
 
 
-#test_LineSolution()
-#test_ModelSolution()
+# test_LineSolution()
+# test_ModelSolution()
 test_Linefit()

--- a/PySpectrograph/unit_tests/ut_detectlines.py
+++ b/PySpectrograph/unit_tests/ut_detectlines.py
@@ -2,60 +2,62 @@ import numpy as np
 from detectlines import *
 import pylab as pl
 
-infile='Xe.01.spec'
-inlist='Xe.dat'
-plist=[4500.98500001, 4624.28500002, 4671.23500002, 4734.16500002, 4807.02500002, 4916.51500002, 4923.16500002]
-wlist=[4500.9772, 4624.2757, 4671.226, 4734.1524, 4807.019, 4916.51, 4923.152]
+infile = 'Xe.01.spec'
+inlist = 'Xe.dat'
+plist = [4500.98500001, 4624.28500002, 4671.23500002, 4734.16500002, 4807.02500002, 4916.51500002, 4923.16500002]
+wlist = [4500.9772, 4624.2757, 4671.226, 4734.1524, 4807.019, 4916.51, 4923.152]
+
 
 def centroid2(warr, farr, mask):
-  return (warr[mask]*farr[mask]).sum()/farr[mask].sum()
+    return (warr[mask] * farr[mask]).sum() / farr[mask].sum()
 
 
 def test_centroid():
-   xc=30.2
-   gaussian = lambda x: 3*np.exp(-0.5*(xc-x)**2/(3.16**2.))
-   x=np.arange(-50,50)
-   f=gaussian(x)
+    xc = 30.2
+    gaussian = lambda x: 3 * np.exp(-0.5 * (xc - x) ** 2 / (3.16 ** 2.))
+    x = np.arange(-50, 50)
+    f = gaussian(x)
 
-   xc1=centroid(x,f)
+    xc1 = centroid(x, f)
 
-   
-   xdiff=10
-   mask=(abs(x-xc)<xdiff)
+    xdiff = 10
+    mask = (abs(x - xc) < xdiff)
 
-   xcm=centroid(x,f,mask=mask)
+    xcm = centroid(x, f, mask=mask)
 
-   if abs(xc-xc1)>0.01:  
-      print "FAIL", xc, xc1
-   if abs(xc-xcm)>0.01:  
-      print "FAIL", xc, xcm
+    if abs(xc - xc1) > 0.01:
+        print "FAIL", xc, xc1
+    if abs(xc - xcm) > 0.01:
+        print "FAIL", xc, xcm
+
 
 def test_find_backstats():
-   w,f=np.loadtxt(infile, unpack=True)
-   ave, std=find_backstats(f, sigma=3, niter=5)
-   if abs(ave-50)>1 or (std-10)>1:
-      print "FAIL"
+    w, f = np.loadtxt(infile, unpack=True)
+    ave, std = find_backstats(f, sigma=3, niter=5)
+    if abs(ave - 50) > 1 or (std - 10) > 1:
+        print "FAIL"
+
 
 def test_find_peaks():
-   warr,farr=np.loadtxt(infile, unpack=True)
-   xp=find_peaks(farr, 10, 5)
-   wdiff=10
-   for x,w in zip(xp,plist):
-       if warr[x]!=w:
-          print "FAIL", warr[x], w
-   
+    warr, farr = np.loadtxt(infile, unpack=True)
+    xp = find_peaks(farr, 10, 5)
+    wdiff = 10
+    for x, w in zip(xp, plist):
+        if warr[x] != w:
+            print "FAIL", warr[x], w
+
+
 def test_detectlines():
-   wl,fl=np.loadtxt(inlist, usecols=[0,1], unpack=True)
-   warr,farr=np.loadtxt(infile, unpack=True)
-   wp=detectlines(warr, farr, sigma=10, niter=5, bsigma=3, mask=None, kern=default_kernal, center=False)
-   cwp=detectlines(warr, farr, sigma=10, niter=5, bsigma=3, mask=None, kern=default_kernal, center=True)
-   if (np.array(wlist, dtype=float)-wp).mean()>0.01:
-      print 'FAIL center=False'
-   if (np.array(wlist, dtype=float)-cwp).mean()>0.01:
-      print 'FAIL center=True'
+    wl, fl = np.loadtxt(inlist, usecols=[0, 1], unpack=True)
+    warr, farr = np.loadtxt(infile, unpack=True)
+    wp = detectlines(warr, farr, sigma=10, niter=5, bsigma=3, mask=None, kern=default_kernal, center=False)
+    cwp = detectlines(warr, farr, sigma=10, niter=5, bsigma=3, mask=None, kern=default_kernal, center=True)
+    if (np.array(wlist, dtype=float) - wp).mean() > 0.01:
+        print 'FAIL center=False'
+    if (np.array(wlist, dtype=float) - cwp).mean() > 0.01:
+        print 'FAIL center=True'
 
 test_centroid()
 test_find_backstats()
 test_find_peaks()
 test_detectlines()
-

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,7 +11,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import sys
+import os
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -170,21 +171,21 @@ htmlhelp_basename = 'PySpectrographdoc'
 # -- Options for LaTeX output --------------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    #'papersize': 'letterpaper',
 
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    #'pointsize': '10pt',
 
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    #'preamble': '',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'PySpectrograph.tex', u'PySpectrograph Documentation',
-   u'S. M. Crawford', 'manual'),
+    ('index', 'PySpectrograph.tex', u'PySpectrograph Documentation',
+     u'S. M. Crawford', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -227,9 +228,9 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'PySpectrograph', u'PySpectrograph Documentation',
-   u'S. M. Crawford', 'PySpectrograph', 'One line description of project.',
-   'Miscellaneous'),
+    ('index', 'PySpectrograph', u'PySpectrograph Documentation',
+     u'S. M. Crawford', 'PySpectrograph', 'One line description of project.',
+     'Miscellaneous'),
 ]
 
 # Documents to append as an appendix to all manuals.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from distutils.core import setup
-DISTUTILS_DEBUG=True
+DISTUTILS_DEBUG = True
 
 
 setup(name='PySpectrograph',
@@ -10,6 +10,11 @@ setup(name='PySpectrograph',
       author='Steve Crawford',
       author_email='crawfordsm@gmail.com',
       url='http://code.google.com/p/pyspectrograph/',
-      packages=['PySpectrograph', 'PySpectrograph/Spectrograph', 'PySpectrograph/Utilities', 'PySpectrograph/WavelengthSolution', 'PySpectrograph/Spectra', 'PySpectrograph/Models'],
-     )
-
+      packages=[
+          'PySpectrograph',
+          'PySpectrograph/Spectrograph',
+          'PySpectrograph/Utilities',
+          'PySpectrograph/WavelengthSolution',
+          'PySpectrograph/Spectra',
+          'PySpectrograph/Models'],
+      )

--- a/tests/ut_RSSModel.py
+++ b/tests/ut_RSSModel.py
@@ -5,33 +5,32 @@ import PySpectrograph
 from PySpectrograph.Models import RSSModel
 from PySpectrograph.Spectra import Spectrum
 
-#create the spectrograph model
-rss=RSSModel.RSSModel(grating_name="PG0900", gratang=15.875, camang=31.76496, 
-                      slit=1.50, xbin=2, ybin=2)
+# create the spectrograph model
+rss = RSSModel.RSSModel(grating_name="PG0900", gratang=15.875, camang=31.76496,
+                        slit=1.50, xbin=2, ybin=2)
 
 
-#print out some basic statistics
-print 1e7*rss.calc_bluewavelength(), 1e7*rss.calc_centralwavelength(), 1e7*rss.calc_redwavelength()
-R=rss.calc_resolution(rss.calc_centralwavelength(), rss.alpha(), -rss.beta())
-res=1e7*rss.calc_resolelement(rss.alpha(), -rss.beta())
+# print out some basic statistics
+print 1e7 * rss.calc_bluewavelength(), 1e7 * rss.calc_centralwavelength(), 1e7 * rss.calc_redwavelength()
+R = rss.calc_resolution(rss.calc_centralwavelength(), rss.alpha(), -rss.beta())
+res = 1e7 * rss.calc_resolelement(rss.alpha(), -rss.beta())
 print R, res
 
-#set up the detector
-ycen=rss.detector.get_ypixcenter()
-d_arr=rss.detector.make_detector()[ycen,:]
-w=1e7*rss.get_wavelength(xarr)
+# set up the detector
+ycen = rss.detector.get_ypixcenter()
+d_arr = rss.detector.make_detector()[ycen, :]
+w = 1e7 * rss.get_wavelength(xarr)
 
-#set up the artificial spectrum
-sw,sf=pl.loadtxt('Ne.txt', usecols=(0,1), unpack=True)
-wrange=[1e7*rss.calc_bluewavelength(), 1e7*rss.calc_redwavelength()]
-spec=Spectrum.Spectrum(sw, sf, wrange=wrange, dw=res/10, stype='line', sigma=res)
+# set up the artificial spectrum
+sw, sf = pl.loadtxt('Ne.txt', usecols=(0, 1), unpack=True)
+wrange = [1e7 * rss.calc_bluewavelength(), 1e7 * rss.calc_redwavelength()]
+spec = Spectrum.Spectrum(sw, sf, wrange=wrange, dw=res / 10, stype='line', sigma=res)
 
-#interpolate it over the same range as the detector
+# interpolate it over the same range as the detector
 spec.interp(w)
 
 
-
-#plot it
+# plot it
 pl.figure()
-pl.plot(spec.wavelength, d_arr*((spec.flux)/spec.flux.max()))
+pl.plot(spec.wavelength, d_arr * ((spec.flux) / spec.flux.max()))
 pl.show()


### PR DESCRIPTION
i might like to at least crib parts of pyspectrograph, if not use it as a dependency, to refactor how the JWST ETC models the dispersed modes of NIRSpec and NIRISS. but first, i had to make the code style match. so i did:

```
find . -name "*.py" -exec autopep8 -a -i -v --max-line-length 120 {} \;
```

the changes are trivial, yet voluminous. use or discard as you wish...
